### PR TITLE
feat: session-time exercise variants (phase 1) [minor]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,53 +1,69 @@
 ## Description
 
-<!-- Describe your changes in detail -->
+<!-- Describe the goal, user impact, and technical approach. -->
 
-## Type of Change
+## PR Stage (Major Feature Workflow)
 
-<!-- Please check the relevant option -->
+<!-- For major features, keep one long-lived PR and update this stage over time. -->
 
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] ✨ New feature (non-breaking change which adds functionality)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📝 Documentation update
-- [ ] 🎨 Style/UI change
-- [ ] ♻️ Code refactoring (no functional changes)
-- [ ] 🧪 Test update
-- [ ] 🔧 Configuration change
+- [ ] Draft
+- [ ] In Progress
+- [ ] Merge Candidate
 
-## Version Bump
+## Scope Type
 
-<!-- Select the appropriate version bump type (default is patch) -->
-<!-- IMPORTANT: the version workflow uses commit message keywords, not PR labels. -->
-<!-- Include one keyword in the merge/squash commit title/message: [patch], [minor], or [major]. -->
-<!-- If omitted, it defaults to patch. -->
+- [ ] Major feature (single long-lived draft PR)
+- [ ] Maintenance/dependency update (separate from feature PRs)
+- [ ] Bug fix
+- [ ] Documentation-only change
 
-- [ ] Patch (bug fixes, minor changes) - default
-- [ ] Minor (new features, backward compatible)
-- [ ] Major (breaking changes)
+## Iteration Log
+
+<!-- Keep this updated each time the PR is refreshed. -->
+
+- Date:
+- Iteration summary:
+- Risk notes:
+- Follow-up items:
+
+## Version Bump Keyword (merge commit)
+
+<!-- The version workflow reads commit keywords on push to main. -->
+<!-- Include one keyword in the merge/squash commit: [patch], [minor], or [major]. -->
+
+- [ ] [patch] (fixes, docs, tests, maintenance)
+- [ ] [minor] (new backward-compatible feature)
+- [ ] [major] (breaking change)
+
+## Required Gate Status
+
+<!-- Mark only when each gate is green for this PR revision. -->
+
+- [ ] `npm run lint:ratchet`
+- [ ] `npm run test:app`
+- [ ] `npm run test:app:offline`
+- [ ] `npm run test:coverage:gate`
+- [ ] `npm run test:no-skips`
+
+## Testing and Validation
+
+<!-- List added/updated tests and manual checks. -->
+
+- Automated tests updated:
+- Manual validation done:
+- Offline/retry behavior checked (if touched):
 
 ## Checklist
 
-<!-- Please check all that apply -->
-
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published
+- [ ] I performed a self-review
+- [ ] Docs are updated for behavior/process changes
+- [ ] No unrelated changes were mixed into this PR
+- [ ] New or changed behavior has test coverage
 
 ## Related Issues
 
-<!-- Link any related issues here -->
-<!-- Example: Fixes #123, Closes #456 -->
+<!-- Example: Closes #123 -->
 
 ## Screenshots (if applicable)
 
-<!-- Add screenshots to help explain your changes -->
-
 ## Additional Notes
-
-<!-- Add any additional information that reviewers should know -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing Guide
+
+## PR-First Workflow (Soft Policy)
+
+This repository uses a PR-first workflow for major features.
+
+- One branch + one draft PR per major feature.
+- Keep iterating inside the same PR until merge-safe.
+- Do not split a major feature into unrelated parallel PRs unless a separate maintenance task requires it.
+- This is policy-driven for now (no branch-protection automation changes in this phase).
+
+## Major Feature Lifecycle
+
+Use these stages in the PR description as work progresses:
+
+1. Draft
+2. In Progress
+3. Merge Candidate
+
+A major feature PR starts as Draft and only moves to Merge Candidate when all required gates are green and review feedback is resolved.
+
+## Required Gates Before Merge
+
+Every major feature PR must pass:
+
+- `npm run lint:ratchet`
+- `npm run test:app`
+- `npm run test:app:offline`
+- `npm run test:coverage:gate`
+- `npm run test:no-skips`
+
+## Version Keyword Rule
+
+Version bumping is driven by commit message keywords on merge to `main`.
+
+- Use `[minor]` for new backward-compatible features.
+- Use `[patch]` for fixes, docs, tests, and refactors.
+- Use `[major]` only for intentional breaking changes.
+
+For the current major feature kickoff below, default to `[minor]` unless scope changes to breaking behavior.
+
+## Dependency and Maintenance PRs
+
+Keep maintenance PRs separate from major-feature PRs.
+
+Examples:
+
+- Dependabot updates
+- CI toolchain updates
+- Standalone docs-only or test-only maintenance
+
+## Current Major Feature Kickoff
+
+Milestone: Session-Time Exercise Variants + ES/EN Language System
+
+- Branch: `feature/session-variants-v1`
+- Draft PR title: `feat: session-time exercise variants (phase 1) [minor]`
+- Phase 1 scope (this PR):
+  - per-exercise session controls for `executionMode` and `loadType`
+  - precedence: in-progress snapshot > local override > routine default
+  - local persistence by user + routine + exercise
+  - save effective values to `modoEjecucion` and `tipoCarga`
+  - keep offline queue/replay behavior unchanged
+- Out of scope for phase 1:
+  - ES/EN i18n language system (phase 2)
+  - Firestore schema changes

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Then open:
 
 Planning docs:
 
+- [CONTRIBUTING.md](CONTRIBUTING.md) - PR-first contribution workflow and major-feature lifecycle policy
 - [UPGRADE-PLAN.md](UPGRADE-PLAN.md) - single source of truth for the 6-week roadmap
 - [TESTING-PLAN.md](TESTING-PLAN.md) - testing policy and enforcement rules
 - [docs/quick-log-daily-hub-readiness.md](docs/quick-log-daily-hub-readiness.md) - acceptance criteria and rollout checklist for the first feature/fun slice
@@ -81,6 +82,13 @@ Planning docs:
 
 Current feature/fun implementation targets delivered: `Quick Log + Daily Hub`, `Exercise Execution Modes`.
 Next target (pending): `Session-Time Exercise Variants + ES/EN Language System`.
+
+### How We Ship Major Features
+
+- Use one long-lived draft PR per major feature until merge-safe.
+- Track PR stage as `Draft` -> `In Progress` -> `Merge Candidate`.
+- Keep dependency/maintenance PRs separate from major feature PRs.
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for full workflow and gate rules.
 
 ## License and Copyright
 

--- a/css/components/exercise-cache.css
+++ b/css/components/exercise-cache.css
@@ -1,5 +1,24 @@
 /* Exercise Cache Components */
 
+.session-variant-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 8px;
+    margin: 10px 0;
+}
+
+.session-variant-field label {
+    margin-bottom: 4px;
+}
+
+.session-variant-field select {
+    margin-bottom: 0;
+}
+
+.session-bodyweight-hint {
+    margin-top: 6px;
+}
+
 /* Last workout information display */
 .last-workout-info {
     background: var(--card-bg);

--- a/js/modules/session-manager.js
+++ b/js/modules/session-manager.js
@@ -625,7 +625,7 @@ export function setupSessionAutoSave() {
         if (e.target.classList.contains('timer-button') && currentRoutineForSession) {
             // Add a small delay to let the timer update
             setTimeout(() => {
-                const formData = getSessionFormData();
+                const formData = getSessionFormData({ includeEmptyExercises: true });
                 saveInProgressSession(currentRoutineForSession.id, formData);
             }, 100);
         }

--- a/js/modules/session-manager.js
+++ b/js/modules/session-manager.js
@@ -206,9 +206,15 @@ export function setCurrentRoutineForSession(routine) {
 
 /**
  * Collects form data from the current session
+ * @param {Object} options - Collection options.
+ * @param {boolean} [options.includeEmptyExercises=false] - Include exercises even when they have no sets/notes.
  * @returns {Object} The session data from the form
  */
-export function getSessionFormData() {
+export function getSessionFormData(options = {}) {
+    const {
+        includeEmptyExercises = false
+    } = options;
+
     if (!currentRoutineForSession) return {};
     
     // Get and normalize user weight
@@ -235,8 +241,15 @@ export function getSessionFormData() {
     
     const exerciseBlocks = sessionElements.exerciseList.querySelectorAll('.exercise-block');
     exerciseBlocks.forEach(block => {
-        const exerciseIndex = parseInt(block.dataset.exerciseIndex);
-        const exerciseFromRoutine = currentRoutineForSession.exercises[exerciseIndex];
+        const exerciseIndex = parseInt(block.dataset.exerciseIndex, 10);
+        if (Number.isNaN(exerciseIndex)) {
+            return;
+        }
+
+        const exerciseFromRoutine = currentRoutineForSession.exercises?.[exerciseIndex];
+        if (!exerciseFromRoutine) {
+            return;
+        }
         
         const exerciseEntry = {
             nombreEjercicio: exerciseFromRoutine.name,
@@ -247,6 +260,8 @@ export function getSessionFormData() {
             sets: [],
             notasEjercicio: block.querySelector(`textarea[name="notes-${exerciseIndex}"]`)?.value.trim() || ''
         };
+
+        let shouldIncludeExercise = exerciseEntry.notasEjercicio.length > 0;
 
         if (exerciseFromRoutine.type === 'strength') {
             const executionModeInput = block.querySelector('select[name="session-execution-mode"]');
@@ -297,10 +312,11 @@ export function getSessionFormData() {
                     exerciseEntry.sets.push(setEntry);
                 }
             });
+
+            shouldIncludeExercise = shouldIncludeExercise || exerciseEntry.sets.length > 0;
         }
 
-        // Only add exercise if it has sets (for strength) or notes
-        if ((exerciseFromRoutine.type === 'strength' && exerciseEntry.sets.length > 0) || exerciseEntry.notasEjercicio) {
+        if (includeEmptyExercises || shouldIncludeExercise) {
             sessionData.ejercicios.push(exerciseEntry);
         }
     });
@@ -344,6 +360,12 @@ export async function saveSessionData(onSuccess) {
     isSavingSession = true;
     
     try {
+        try {
+            saveSessionVariantOverrides(user.uid, sessionVariantOverrides);
+        } catch (overridesError) {
+            logger.warn('Could not persist session variant overrides:', overridesError);
+        }
+
         const saveOperation = async () => {
             const userSessionsCollectionRef = collection(db, 'users', user.uid, 'sesiones_entrenamiento');
             await addDoc(userSessionsCollectionRef, finalSessionData);
@@ -360,7 +382,6 @@ export async function saveSessionData(onSuccess) {
             }
         );
 
-        saveSessionVariantOverrides(user.uid, sessionVariantOverrides);
         saveLastKnownBodyweight(user.uid, finalSessionData.pesoUsuario);
         
         // Update exercise cache with new session data
@@ -591,7 +612,7 @@ export function setupSessionAutoSave() {
     
     const persistCurrentSnapshot = () => {
         if (!currentRoutineForSession) return;
-        const formData = getSessionFormData();
+        const formData = getSessionFormData({ includeEmptyExercises: true });
         saveInProgressSession(currentRoutineForSession.id, formData);
     };
 

--- a/js/modules/session-manager.js
+++ b/js/modules/session-manager.js
@@ -19,6 +19,7 @@ import { localFirstCache } from '../utils/local-first-cache.js';
 import { firebaseUsageTracker } from '../utils/firebase-usage-tracker.js';
 import { normalizeExecutionMode } from '../utils/execution-mode.js';
 import { normalizeLoadType, resolveExerciseLoadType } from '../utils/load-type.js';
+import { saveSessionVariantOverrides } from '../utils/session-variant-overrides.js';
 import {
     getLastKnownBodyweight,
     saveLastKnownBodyweight,
@@ -36,6 +37,50 @@ const IN_PROGRESS_SESSION_KEY = 'gymTracker_inProgressSession';
 let currentRoutineForSession = null;
 let isSavingSession = false;
 let isSavingQuickLog = false;
+
+function collectSessionVariantOverridesFromDom(
+    routine = currentRoutineForSession,
+    exerciseListRoot = sessionElements.exerciseList
+) {
+    if (!routine?.id || !exerciseListRoot) {
+        return [];
+    }
+
+    const overrides = [];
+    const exerciseBlocks = exerciseListRoot.querySelectorAll('.exercise-block');
+
+    exerciseBlocks.forEach((block) => {
+        const exerciseIndex = parseInt(block.dataset.exerciseIndex, 10);
+        if (Number.isNaN(exerciseIndex)) {
+            return;
+        }
+
+        const routineExercise = routine.exercises?.[exerciseIndex];
+        if (!routineExercise || routineExercise.type !== 'strength') {
+            return;
+        }
+
+        const executionModeInput = block.querySelector('select[name="session-execution-mode"]');
+        const loadTypeInput = block.querySelector('select[name="session-load-type"]');
+
+        overrides.push({
+            routineId: routine.id,
+            exerciseName: routineExercise.name,
+            executionMode: normalizeExecutionMode(
+                executionModeInput?.value
+                ?? block.dataset.executionMode
+                ?? routineExercise.executionMode
+            ),
+            loadType: normalizeLoadType(
+                loadTypeInput?.value
+                ?? block.dataset.loadType
+                ?? resolveExerciseLoadType(routineExercise)
+            )
+        });
+    });
+
+    return overrides;
+}
 
 function buildSessionQueuePayload(userId, sessionData) {
     const { fecha, ...rest } = sessionData;
@@ -204,8 +249,19 @@ export function getSessionFormData() {
         };
 
         if (exerciseFromRoutine.type === 'strength') {
-            exerciseEntry.modoEjecucion = normalizeExecutionMode(exerciseFromRoutine.executionMode);
-            exerciseEntry.tipoCarga = normalizeLoadType(resolveExerciseLoadType(exerciseFromRoutine));
+            const executionModeInput = block.querySelector('select[name="session-execution-mode"]');
+            const loadTypeInput = block.querySelector('select[name="session-load-type"]');
+
+            exerciseEntry.modoEjecucion = normalizeExecutionMode(
+                executionModeInput?.value
+                ?? block.dataset.executionMode
+                ?? exerciseFromRoutine.executionMode
+            );
+            exerciseEntry.tipoCarga = normalizeLoadType(
+                loadTypeInput?.value
+                ?? block.dataset.loadType
+                ?? resolveExerciseLoadType(exerciseFromRoutine)
+            );
             const setRows = block.querySelectorAll('.set-row');
             setRows.forEach((row, setIndex) => {
                 const weightInput = row.querySelector(`input[name="weight-${exerciseIndex}-${setIndex}"]`);
@@ -274,6 +330,7 @@ export async function saveSessionData(onSuccess) {
         return;
     }
     
+    const sessionVariantOverrides = collectSessionVariantOverridesFromDom(currentRoutineForSession);
     const finalSessionData = {
         fecha: Timestamp.now(),
         routineId: currentRoutineForSession.id,
@@ -303,6 +360,7 @@ export async function saveSessionData(onSuccess) {
             }
         );
 
+        saveSessionVariantOverrides(user.uid, sessionVariantOverrides);
         saveLastKnownBodyweight(user.uid, finalSessionData.pesoUsuario);
         
         // Update exercise cache with new session data
@@ -531,12 +589,15 @@ export function setupSessionAutoSave() {
         return;
     }
     
-    // Listen for input events to save form data
-    sessionElements.exerciseList.addEventListener('input', () => {
+    const persistCurrentSnapshot = () => {
         if (!currentRoutineForSession) return;
         const formData = getSessionFormData();
         saveInProgressSession(currentRoutineForSession.id, formData);
-    });
+    };
+
+    // Listen for input/change events to save form data.
+    sessionElements.exerciseList.addEventListener('input', persistCurrentSnapshot);
+    sessionElements.exerciseList.addEventListener('change', persistCurrentSnapshot);
     
     // Listen for timer events to save timer data
     sessionElements.exerciseList.addEventListener('click', (e) => {

--- a/js/ui.js
+++ b/js/ui.js
@@ -65,6 +65,32 @@ function formatSignedWeight(value) {
     return `${numericValue}`;
 }
 
+function normalizeExerciseIdentity(exerciseName = '') {
+    return String(exerciseName || '')
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, ' ');
+}
+
+function resolveInProgressExercise(inProgressData, exerciseIndex, exerciseName) {
+    const inProgressExercises = Array.isArray(inProgressData?.ejercicios)
+        ? inProgressData.ejercicios
+        : [];
+    const indexedExercise = inProgressExercises[exerciseIndex];
+    if (indexedExercise && typeof indexedExercise === 'object') {
+        return indexedExercise;
+    }
+
+    const normalizedExerciseName = normalizeExerciseIdentity(exerciseName);
+    if (!normalizedExerciseName) {
+        return null;
+    }
+
+    return inProgressExercises.find((exerciseEntry) =>
+        normalizeExerciseIdentity(exerciseEntry?.nombreEjercicio) === normalizedExerciseName
+    ) || null;
+}
+
 export const views = {
     auth: document.getElementById('auth-view'),
     dashboard: document.getElementById('dashboard-view'),
@@ -362,6 +388,7 @@ export async function renderSessionView(routine, inProgressData = null) {
 
     for (let exerciseIndex = 0; exerciseIndex < routine.exercises.length; exerciseIndex++) {
         const exercise = routine.exercises[exerciseIndex];
+        const inProgressExercise = resolveInProgressExercise(inProgressData, exerciseIndex, exercise.name);
         const exerciseBlock = document.createElement('div');
         exerciseBlock.className = 'exercise-block';
         exerciseBlock.dataset.exerciseIndex = exerciseIndex;
@@ -386,7 +413,6 @@ export async function renderSessionView(routine, inProgressData = null) {
         exerciseBlock.appendChild(target);
 
         if (exercise.type === 'strength') {
-            const inProgressExercise = inProgressData?.ejercicios?.[exerciseIndex] || null;
             const localOverride = getSessionVariantOverride(currentUserId, routine.id, exercise.name);
             const selectedVariant = resolveSessionVariantSelection({
                 inProgressExercise,
@@ -699,8 +725,8 @@ export async function renderSessionView(routine, inProgressData = null) {
             : 'Añade notas sobre este ejercicio...';
         notesTextarea.className = 'exercise-notes';
 
-        if (inProgressData?.ejercicios?.[exerciseIndex]?.notasEjercicio) {
-            notesTextarea.value = inProgressData.ejercicios[exerciseIndex].notasEjercicio;
+        if (inProgressExercise?.notasEjercicio) {
+            notesTextarea.value = inProgressExercise.notasEjercicio;
         } else if (exercise.notes) {
             notesTextarea.value = exercise.notes;
         }

--- a/js/ui.js
+++ b/js/ui.js
@@ -76,12 +76,15 @@ function resolveInProgressExercise(inProgressData, exerciseIndex, exerciseName) 
     const inProgressExercises = Array.isArray(inProgressData?.ejercicios)
         ? inProgressData.ejercicios
         : [];
+    const normalizedExerciseName = normalizeExerciseIdentity(exerciseName);
     const indexedExercise = inProgressExercises[exerciseIndex];
     if (indexedExercise && typeof indexedExercise === 'object') {
-        return indexedExercise;
+        const normalizedIndexedName = normalizeExerciseIdentity(indexedExercise?.nombreEjercicio);
+        if (!normalizedExerciseName || normalizedIndexedName === normalizedExerciseName) {
+            return indexedExercise;
+        }
     }
 
-    const normalizedExerciseName = normalizeExerciseIdentity(exerciseName);
     if (!normalizedExerciseName) {
         return null;
     }
@@ -565,6 +568,25 @@ export async function renderSessionView(routine, inProgressData = null) {
                 return `${integerPart}${decimalPart ? `.${decimalPart}` : ''}`;
             };
 
+            const formatWeightSuggestionPlaceholder = (rawWeight, placeholderType, allowSignedLoad) => {
+                const normalizedPlaceholderType = placeholderType || '';
+                const numericWeight = Number(rawWeight);
+
+                if (Number.isFinite(numericWeight) && normalizedPlaceholderType === 'last') {
+                    return allowSignedLoad
+                        ? `Último extra: ${formatSignedWeight(numericWeight)}kg`
+                        : `Último: ${numericWeight}kg`;
+                }
+
+                if (Number.isFinite(numericWeight) && normalizedPlaceholderType === 'suggested') {
+                    return allowSignedLoad
+                        ? `Extra sugerido: ${formatSignedWeight(numericWeight)}kg`
+                        : `Sugerido: ${numericWeight}kg`;
+                }
+
+                return allowSignedLoad ? 'Carga extra (kg, +/-)' : 'Peso (kg)';
+            };
+
             const numberOfSets = parseInt(exercise.sets, 10) || 0;
             for (let i = 0; i < numberOfSets; i++) {
                 const setRow = document.createElement('div');
@@ -581,23 +603,27 @@ export async function renderSessionView(routine, inProgressData = null) {
                 weightInput.id = `weight-${exerciseIndex}-${i}`;
                 weightInput.name = `weight-${exerciseIndex}-${i}`;
 
-                let placeholderText = allowsSignedLoadInSuggestion ? 'Carga extra (kg, +/-)' : 'Peso (kg)';
+                let placeholderType = 'default';
+                let suggestionWeight = null;
                 if (suggestions.hasHistory && suggestions.suggestions.lastSets[i]) {
                     const lastSet = suggestions.suggestions.lastSets[i];
                     if (lastSet && Number.isFinite(Number(lastSet.peso))) {
-                        placeholderText = allowsSignedLoadInSuggestion
-                            ? `Último extra: ${formatSignedWeight(lastSet.peso)}kg`
-                            : `Último: ${lastSet.peso}kg`;
-                        weightInput.dataset.suggestion = lastSet.peso;
+                        placeholderType = 'last';
+                        suggestionWeight = Number(lastSet.peso);
+                        weightInput.dataset.suggestion = String(suggestionWeight);
                     }
                 } else if (suggestions.hasHistory && Number.isFinite(Number(suggestions.suggestions.peso))) {
-                    placeholderText = allowsSignedLoadInSuggestion
-                        ? `Extra sugerido: ${formatSignedWeight(suggestions.suggestions.peso)}kg`
-                        : `Sugerido: ${suggestions.suggestions.peso}kg`;
-                    weightInput.dataset.suggestion = suggestions.suggestions.peso;
+                    placeholderType = 'suggested';
+                    suggestionWeight = Number(suggestions.suggestions.peso);
+                    weightInput.dataset.suggestion = String(suggestionWeight);
                 }
 
-                weightInput.placeholder = placeholderText;
+                weightInput.dataset.placeholderType = placeholderType;
+                weightInput.placeholder = formatWeightSuggestionPlaceholder(
+                    suggestionWeight,
+                    placeholderType,
+                    allowsSignedLoadInSuggestion
+                );
                 weightInput.inputMode = 'decimal';
                 weightInput.pattern = initialLoadType === 'bodyweight'
                     ? '[+-]?[0-9]*[.,]?[0-9]*'
@@ -696,6 +722,11 @@ export async function renderSessionView(routine, inProgressData = null) {
                     weightInput.pattern = allowSignedLoad
                         ? '[+-]?[0-9]*[.,]?[0-9]*'
                         : '[0-9]*[.,]?[0-9]*';
+                    weightInput.placeholder = formatWeightSuggestionPlaceholder(
+                        weightInput.dataset.suggestion,
+                        weightInput.dataset.placeholderType,
+                        allowSignedLoad
+                    );
                     weightInput.value = sanitizeWeightInputValue(weightInput.value, allowSignedLoad);
                 });
             };

--- a/js/ui.js
+++ b/js/ui.js
@@ -16,6 +16,10 @@ import {
     getLoadTypeLabel
 } from './utils/load-type.js';
 import { getLastKnownBodyweight } from './utils/bodyweight.js';
+import {
+    getSessionVariantOverride,
+    resolveSessionVariantSelection
+} from './utils/session-variant-overrides.js';
 
 // View initializer registry (populated from app.js)
 const viewInitializers = new Map();
@@ -295,16 +299,18 @@ export async function renderSessionView(routine, inProgressData = null) {
 
     sessionElements.title.textContent = routine.name;
     sessionElements.exerciseList.innerHTML = '';
-    
-    // Add user weight input field
+
+    const { getCurrentUser } = await import('./auth.js');
+    const currentUserId = getCurrentUser()?.uid || null;
+
     const userWeightDiv = document.createElement('div');
     userWeightDiv.className = 'user-weight-input';
-    
+
     const userWeightLabel = document.createElement('label');
     userWeightLabel.textContent = 'Tu peso hoy (kg):';
     userWeightLabel.htmlFor = 'user-weight';
     userWeightDiv.appendChild(userWeightLabel);
-    
+
     const userWeightInput = document.createElement('input');
     userWeightInput.type = 'text';
     userWeightInput.id = 'user-weight';
@@ -312,8 +318,7 @@ export async function renderSessionView(routine, inProgressData = null) {
     userWeightInput.placeholder = 'Introduce tu peso (kg)';
     userWeightInput.inputMode = 'decimal';
     userWeightInput.pattern = '[0-9]*[.,]?[0-9]*';
-    
-    // Replace comma with period and validate format
+
     userWeightInput.addEventListener('input', function(e) {
         let value = e.target.value;
         value = value.replace(',', '.');
@@ -327,8 +332,7 @@ export async function renderSessionView(routine, inProgressData = null) {
         }
         e.target.value = value;
     });
-    
-    // Validate range and round to 1 decimal on blur
+
     userWeightInput.addEventListener('blur', function(e) {
         const value = e.target.value.replace(',', '.');
         if (value && !isNaN(value)) {
@@ -343,20 +347,19 @@ export async function renderSessionView(routine, inProgressData = null) {
             }
         }
     });
-    
+
     if (inProgressData?.pesoUsuario) {
         userWeightInput.value = inProgressData.pesoUsuario;
     } else {
-        const { getCurrentUser } = await import('./auth.js');
-        const lastKnownBodyweight = getLastKnownBodyweight(getCurrentUser()?.uid);
+        const lastKnownBodyweight = getLastKnownBodyweight(currentUserId);
         if (lastKnownBodyweight !== null) {
             userWeightInput.value = lastKnownBodyweight;
         }
     }
+
     userWeightDiv.appendChild(userWeightInput);
     sessionElements.exerciseList.appendChild(userWeightDiv);
 
-    // Process exercises with proper async handling
     for (let exerciseIndex = 0; exerciseIndex < routine.exercises.length; exerciseIndex++) {
         const exercise = routine.exercises[exerciseIndex];
         const exerciseBlock = document.createElement('div');
@@ -379,31 +382,88 @@ export async function renderSessionView(routine, inProgressData = null) {
         } else {
             target.textContent = `Objetivo: ${exercise.reps || 'Completar'}`;
         }
-        exerciseBlock.appendChild(target);
-        
-        // Inputs for sets
-        if (exercise.type === 'strength') {
-            const executionMode = normalizeExecutionMode(exercise.executionMode);
-            const loadType = normalizeLoadType(exercise.loadType ?? exercise.tipoCarga);
-            const executionModeLabel = getExecutionModeLabel(executionMode);
-            const loadTypeLabel = getLoadTypeLabel(loadType);
-            const allowsSignedLoad = loadType === 'bodyweight';
-            const variantLabels = [];
 
-            if (executionMode !== DEFAULT_EXECUTION_MODE) {
+        exerciseBlock.appendChild(target);
+
+        if (exercise.type === 'strength') {
+            const inProgressExercise = inProgressData?.ejercicios?.[exerciseIndex] || null;
+            const localOverride = getSessionVariantOverride(currentUserId, routine.id, exercise.name);
+            const selectedVariant = resolveSessionVariantSelection({
+                inProgressExercise,
+                localOverride,
+                routineExercise: exercise
+            });
+
+            const initialExecutionMode = selectedVariant.executionMode;
+            const initialLoadType = selectedVariant.loadType;
+            const executionModeLabel = getExecutionModeLabel(initialExecutionMode);
+            const loadTypeLabel = getLoadTypeLabel(initialLoadType);
+            const allowsSignedLoadInSuggestion = initialLoadType === 'bodyweight';
+
+            exerciseBlock.dataset.executionMode = initialExecutionMode;
+            exerciseBlock.dataset.loadType = initialLoadType;
+
+            const variantLabels = [];
+            if (initialExecutionMode !== DEFAULT_EXECUTION_MODE) {
                 variantLabels.push(executionModeLabel);
             }
-            if (loadType !== DEFAULT_LOAD_TYPE) {
+            if (initialLoadType !== DEFAULT_LOAD_TYPE) {
                 variantLabels.push(loadTypeLabel);
             }
 
             const variantSuffix = variantLabels.length > 0 ? ` (${variantLabels.join(', ')})` : '';
 
-            // Get suggestions from cache for this exercise + variant
-            const { exerciseCache } = await import('./exercise-cache.js');
-            const suggestions = exerciseCache.getExerciseSuggestions(exercise.name, executionMode, loadType);
+            const variantControls = document.createElement('div');
+            variantControls.className = 'session-variant-controls';
 
-            // Show last workout info if available
+            const executionModeField = document.createElement('div');
+            executionModeField.className = 'session-variant-field';
+            const executionModeLabelElement = document.createElement('label');
+            executionModeLabelElement.htmlFor = `session-execution-mode-${exerciseIndex}`;
+            executionModeLabelElement.textContent = 'Modo de ejecucion:';
+            executionModeField.appendChild(executionModeLabelElement);
+
+            const executionModeSelect = document.createElement('select');
+            executionModeSelect.id = `session-execution-mode-${exerciseIndex}`;
+            executionModeSelect.name = 'session-execution-mode';
+            executionModeSelect.innerHTML = `
+                <option value="one_hand">Una mano</option>
+                <option value="two_hand">Dos manos</option>
+                <option value="machine">Maquina</option>
+                <option value="pulley">Polea</option>
+                <option value="other">Otro</option>
+            `;
+            executionModeSelect.value = initialExecutionMode;
+            executionModeField.appendChild(executionModeSelect);
+            variantControls.appendChild(executionModeField);
+
+            const loadTypeField = document.createElement('div');
+            loadTypeField.className = 'session-variant-field';
+            const loadTypeLabelElement = document.createElement('label');
+            loadTypeLabelElement.htmlFor = `session-load-type-${exerciseIndex}`;
+            loadTypeLabelElement.textContent = 'Tipo de carga:';
+            loadTypeField.appendChild(loadTypeLabelElement);
+
+            const loadTypeSelect = document.createElement('select');
+            loadTypeSelect.id = `session-load-type-${exerciseIndex}`;
+            loadTypeSelect.name = 'session-load-type';
+            loadTypeSelect.innerHTML = `
+                <option value="external">Carga externa</option>
+                <option value="bodyweight">Peso corporal (+/-)</option>
+            `;
+            loadTypeSelect.value = initialLoadType;
+            loadTypeField.appendChild(loadTypeSelect);
+            variantControls.appendChild(loadTypeField);
+
+            exerciseBlock.appendChild(variantControls);
+
+            const { exerciseCache } = await import('./exercise-cache.js');
+            const suggestions = exerciseCache.getExerciseSuggestions(
+                exercise.name,
+                initialExecutionMode,
+                initialLoadType
+            );
+
             if (suggestions.hasHistory) {
                 const lastWorkoutInfo = document.createElement('div');
                 lastWorkoutInfo.className = 'last-workout-info';
@@ -420,7 +480,7 @@ export async function renderSessionView(routine, inProgressData = null) {
                     </div>
                     <div class="last-workout-details">
                         ${suggestions.suggestions.lastSets.map((set, idx) => {
-        const loadValue = allowsSignedLoad
+        const loadValue = allowsSignedLoadInSuggestion
             ? `${formatSignedWeight(set.peso)}kg extra`
             : `${set.peso}kg`;
         return `<span class="last-set">S${idx + 1}: ${escapeHtml(loadValue)} × ${escapeHtml(set.reps)}</span>`;
@@ -428,8 +488,7 @@ export async function renderSessionView(routine, inProgressData = null) {
                     </div>
                 `;
 
-                // Add button to use previous values
-                if (!inProgressData?.ejercicios[exerciseIndex]) {
+                if (!inProgressExercise) {
                     const useLastBtn = document.createElement('button');
                     useLastBtn.type = 'button';
                     useLastBtn.className = 'btn btn-secondary btn-sm';
@@ -443,24 +502,23 @@ export async function renderSessionView(routine, inProgressData = null) {
 
                 exerciseBlock.appendChild(lastWorkoutInfo);
             } else {
-                // Show message when no history
                 const noHistoryInfo = document.createElement('div');
                 noHistoryInfo.className = 'no-exercise-history';
                 noHistoryInfo.textContent = '💡 Primera vez haciendo este ejercicio. ¡Registra tus datos para futuras referencias!';
                 exerciseBlock.appendChild(noHistoryInfo);
             }
 
-            if (allowsSignedLoad) {
-                const bodyweightInfo = document.createElement('p');
-                bodyweightInfo.className = 'target-info';
-                bodyweightInfo.textContent = 'Carga de peso corporal: usa negativo para asistido y positivo para lastre.';
-                exerciseBlock.appendChild(bodyweightInfo);
-            }
+            const bodyweightInfo = document.createElement('p');
+            bodyweightInfo.className = 'target-info session-bodyweight-hint';
+            bodyweightInfo.textContent = 'Carga de peso corporal: usa negativo para asistido y positivo para lastre.';
+            exerciseBlock.appendChild(bodyweightInfo);
 
-            const sanitizeWeightInputValue = (rawValue) => {
+            const isBodyweightSelected = () => normalizeLoadType(loadTypeSelect.value) === 'bodyweight';
+
+            const sanitizeWeightInputValue = (rawValue, allowSignedLoad = isBodyweightSelected()) => {
                 let value = (rawValue || '').replace(',', '.');
 
-                if (allowsSignedLoad) {
+                if (allowSignedLoad) {
                     value = value.replace(/[^0-9.+-]/g, '');
                     const sign = value.startsWith('-')
                         ? '-'
@@ -481,7 +539,7 @@ export async function renderSessionView(routine, inProgressData = null) {
                 return `${integerPart}${decimalPart ? `.${decimalPart}` : ''}`;
             };
 
-            const numberOfSets = parseInt(exercise.sets) || 0;
+            const numberOfSets = parseInt(exercise.sets, 10) || 0;
             for (let i = 0; i < numberOfSets; i++) {
                 const setRow = document.createElement('div');
                 setRow.className = 'set-row';
@@ -497,36 +555,35 @@ export async function renderSessionView(routine, inProgressData = null) {
                 weightInput.id = `weight-${exerciseIndex}-${i}`;
                 weightInput.name = `weight-${exerciseIndex}-${i}`;
 
-                // Use cache suggestion if available
-                let placeholderText = allowsSignedLoad ? 'Carga extra (kg, +/-)' : 'Peso (kg)';
+                let placeholderText = allowsSignedLoadInSuggestion ? 'Carga extra (kg, +/-)' : 'Peso (kg)';
                 if (suggestions.hasHistory && suggestions.suggestions.lastSets[i]) {
                     const lastSet = suggestions.suggestions.lastSets[i];
                     if (lastSet && Number.isFinite(Number(lastSet.peso))) {
-                        placeholderText = allowsSignedLoad
+                        placeholderText = allowsSignedLoadInSuggestion
                             ? `Último extra: ${formatSignedWeight(lastSet.peso)}kg`
                             : `Último: ${lastSet.peso}kg`;
                         weightInput.dataset.suggestion = lastSet.peso;
                     }
                 } else if (suggestions.hasHistory && Number.isFinite(Number(suggestions.suggestions.peso))) {
-                    placeholderText = allowsSignedLoad
+                    placeholderText = allowsSignedLoadInSuggestion
                         ? `Extra sugerido: ${formatSignedWeight(suggestions.suggestions.peso)}kg`
                         : `Sugerido: ${suggestions.suggestions.peso}kg`;
                     weightInput.dataset.suggestion = suggestions.suggestions.peso;
                 }
+
                 weightInput.placeholder = placeholderText;
                 weightInput.inputMode = 'decimal';
-                weightInput.pattern = allowsSignedLoad
+                weightInput.pattern = initialLoadType === 'bodyweight'
                     ? '[+-]?[0-9]*[.,]?[0-9]*'
                     : '[0-9]*[.,]?[0-9]*';
 
-                // Replace comma with period and validate format
                 weightInput.addEventListener('input', function(e) {
                     e.target.value = sanitizeWeightInputValue(e.target.value);
                 });
 
-                // Round to 1 decimal on blur
                 weightInput.addEventListener('blur', function(e) {
-                    const sanitizedValue = sanitizeWeightInputValue(e.target.value);
+                    const allowSignedLoad = isBodyweightSelected();
+                    const sanitizedValue = sanitizeWeightInputValue(e.target.value, allowSignedLoad);
                     if (!sanitizedValue || sanitizedValue === '+' || sanitizedValue === '-') {
                         e.target.value = '';
                         return;
@@ -538,15 +595,15 @@ export async function renderSessionView(routine, inProgressData = null) {
                         return;
                     }
 
-                    const minValue = allowsSignedLoad ? -500 : 0;
+                    const minValue = allowSignedLoad ? -500 : 0;
                     const maxValue = 500;
                     const bounded = Math.min(maxValue, Math.max(minValue, parsed));
                     const rounded = Math.round(bounded * 10) / 10;
                     e.target.value = rounded;
                 });
 
-                if (inProgressData?.ejercicios[exerciseIndex]?.sets[i]) {
-                    weightInput.value = inProgressData.ejercicios[exerciseIndex].sets[i].peso || '';
+                if (inProgressExercise?.sets?.[i]) {
+                    weightInput.value = inProgressExercise.sets[i].peso || '';
                 }
                 setRow.appendChild(weightInput);
 
@@ -555,7 +612,6 @@ export async function renderSessionView(routine, inProgressData = null) {
                 repsInput.id = `reps-${exerciseIndex}-${i}`;
                 repsInput.name = `reps-${exerciseIndex}-${i}`;
 
-                // Use cache suggestion if available
                 let repsPlaceholder = 'Reps';
                 if (suggestions.hasHistory && suggestions.suggestions.lastSets[i]) {
                     const lastSet = suggestions.suggestions.lastSets[i];
@@ -569,20 +625,11 @@ export async function renderSessionView(routine, inProgressData = null) {
                 }
                 repsInput.placeholder = repsPlaceholder;
                 repsInput.min = '0';
-                if (inProgressData?.ejercicios[exerciseIndex]?.sets[i]) {
-                    repsInput.value = inProgressData.ejercicios[exerciseIndex].sets[i].reps || '';
+                if (inProgressExercise?.sets?.[i]) {
+                    repsInput.value = inProgressExercise.sets[i].reps || '';
                 }
                 setRow.appendChild(repsInput);
 
-                // If we have saved rest time data, restore it
-                if (inProgressData?.ejercicios[exerciseIndex]?.sets[i]?.tiempoDescanso) {
-                    const timerDisplay = setRow.querySelector(`#timer-display-${exerciseIndex}-${i}`);
-                    if (timerDisplay) {
-                        timerDisplay.textContent = inProgressData.ejercicios[exerciseIndex].sets[i].tiempoDescanso;
-                    }
-                }
-
-                // Add the set timer
                 const timerContainer = document.createElement('div');
                 timerContainer.className = 'set-timer';
                 timerContainer.dataset.timerId = `${exerciseIndex}-${i}`;
@@ -590,7 +637,7 @@ export async function renderSessionView(routine, inProgressData = null) {
                 const timerDisplay = document.createElement('div');
                 timerDisplay.id = `timer-display-${exerciseIndex}-${i}`;
                 timerDisplay.className = 'timer-display';
-                timerDisplay.textContent = '00:00';
+                timerDisplay.textContent = inProgressExercise?.sets?.[i]?.tiempoDescanso || '00:00';
                 timerContainer.appendChild(timerDisplay);
 
                 const timerButton = document.createElement('button');
@@ -604,6 +651,32 @@ export async function renderSessionView(routine, inProgressData = null) {
                 setRow.appendChild(timerContainer);
                 exerciseBlock.appendChild(setRow);
             }
+
+            const syncVariantState = () => {
+                const selectedExecutionMode = normalizeExecutionMode(executionModeSelect.value);
+                const selectedLoadType = normalizeLoadType(loadTypeSelect.value);
+                exerciseBlock.dataset.executionMode = selectedExecutionMode;
+                exerciseBlock.dataset.loadType = selectedLoadType;
+
+                if (selectedLoadType === 'bodyweight') {
+                    bodyweightInfo.classList.remove('hidden');
+                } else {
+                    bodyweightInfo.classList.add('hidden');
+                }
+
+                const weightInputs = exerciseBlock.querySelectorAll('input[name^="weight-"]');
+                weightInputs.forEach((weightInput) => {
+                    const allowSignedLoad = selectedLoadType === 'bodyweight';
+                    weightInput.pattern = allowSignedLoad
+                        ? '[+-]?[0-9]*[.,]?[0-9]*'
+                        : '[0-9]*[.,]?[0-9]*';
+                    weightInput.value = sanitizeWeightInputValue(weightInput.value, allowSignedLoad);
+                });
+            };
+
+            executionModeSelect.addEventListener('change', syncVariantState);
+            loadTypeSelect.addEventListener('change', syncVariantState);
+            syncVariantState();
         } else if (exercise.type === 'cardio') {
             const infoPara = document.createElement('p');
             infoPara.textContent = 'Registra los detalles en las notas.';
@@ -611,7 +684,6 @@ export async function renderSessionView(routine, inProgressData = null) {
             infoPara.style.color = '#666';
             exerciseBlock.appendChild(infoPara);
         }
-
 
         const notesLabel = document.createElement('label');
         notesLabel.textContent = 'Notas de la sesión:';
@@ -622,26 +694,27 @@ export async function renderSessionView(routine, inProgressData = null) {
         const notesTextarea = document.createElement('textarea');
         notesTextarea.id = `notes-${exerciseIndex}`;
         notesTextarea.name = `notes-${exerciseIndex}`;
-        notesTextarea.placeholder = exercise.type === 'cardio' ? 'Ej: 20 min a 140bpm, o 5km en 25 min...' : 'Añade notas sobre este ejercicio...';
+        notesTextarea.placeholder = exercise.type === 'cardio'
+            ? 'Ej: 20 min a 140bpm, o 5km en 25 min...'
+            : 'Añade notas sobre este ejercicio...';
         notesTextarea.className = 'exercise-notes';
-        
-        if (inProgressData?.ejercicios[exerciseIndex]?.notasEjercicio) {
+
+        if (inProgressData?.ejercicios?.[exerciseIndex]?.notasEjercicio) {
             notesTextarea.value = inProgressData.ejercicios[exerciseIndex].notasEjercicio;
         } else if (exercise.notes) {
             notesTextarea.value = exercise.notes;
         }
-        
+
         exerciseBlock.appendChild(notesTextarea);
         sessionElements.exerciseList.appendChild(exerciseBlock);
     }
+
     showView('session');
-    
-    // Initialize timers after the view is rendered
+
     import('./timer.js').then(module => {
         module.initSetTimers();
     });
 }
-
 export function renderHistoryList(sessions) {
     historyElements.loadingSpinner.classList.add('hidden');
     historyElements.list.innerHTML = '';

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,6 +18,7 @@ import {
 import { getLastKnownBodyweight } from './utils/bodyweight.js';
 import {
     getSessionVariantOverride,
+    normalizeExerciseIdentity,
     resolveSessionVariantSelection
 } from './utils/session-variant-overrides.js';
 
@@ -63,13 +64,6 @@ function formatSignedWeight(value) {
     }
 
     return `${numericValue}`;
-}
-
-function normalizeExerciseIdentity(exerciseName = '') {
-    return String(exerciseName || '')
-        .trim()
-        .toLowerCase()
-        .replace(/\s+/g, ' ');
 }
 
 function resolveInProgressExercise(inProgressData, exerciseIndex, exerciseName) {
@@ -425,22 +419,9 @@ export async function renderSessionView(routine, inProgressData = null) {
 
             const initialExecutionMode = selectedVariant.executionMode;
             const initialLoadType = selectedVariant.loadType;
-            const executionModeLabel = getExecutionModeLabel(initialExecutionMode);
-            const loadTypeLabel = getLoadTypeLabel(initialLoadType);
-            const allowsSignedLoadInSuggestion = initialLoadType === 'bodyweight';
 
             exerciseBlock.dataset.executionMode = initialExecutionMode;
             exerciseBlock.dataset.loadType = initialLoadType;
-
-            const variantLabels = [];
-            if (initialExecutionMode !== DEFAULT_EXECUTION_MODE) {
-                variantLabels.push(executionModeLabel);
-            }
-            if (initialLoadType !== DEFAULT_LOAD_TYPE) {
-                variantLabels.push(loadTypeLabel);
-            }
-
-            const variantSuffix = variantLabels.length > 0 ? ` (${variantLabels.join(', ')})` : '';
 
             const variantControls = document.createElement('div');
             variantControls.className = 'session-variant-controls';
@@ -487,55 +468,85 @@ export async function renderSessionView(routine, inProgressData = null) {
             exerciseBlock.appendChild(variantControls);
 
             const { exerciseCache } = await import('./exercise-cache.js');
-            const suggestions = exerciseCache.getExerciseSuggestions(
-                exercise.name,
-                initialExecutionMode,
-                initialLoadType
-            );
-
-            if (suggestions.hasHistory) {
-                const lastWorkoutInfo = document.createElement('div');
-                lastWorkoutInfo.className = 'last-workout-info';
-
-                const daysAgo = suggestions.daysSinceLastSession;
-                const timeText = daysAgo === 0 ? 'hoy'
-                    : daysAgo === 1 ? 'ayer'
-                        : `hace ${daysAgo} días`;
-
-                lastWorkoutInfo.innerHTML = `
-                    <div class="last-workout-header">
-                        <span class="last-workout-title">Último entrenamiento${escapeHtml(variantSuffix)}</span>
-                        <span class="workout-time-ago">${escapeHtml(timeText)}</span>
-                    </div>
-                    <div class="last-workout-details">
-                        ${suggestions.suggestions.lastSets.map((set, idx) => {
-        const loadValue = allowsSignedLoadInSuggestion
-            ? `${formatSignedWeight(set.peso)}kg extra`
-            : `${set.peso}kg`;
-        return `<span class="last-set">S${idx + 1}: ${escapeHtml(loadValue)} × ${escapeHtml(set.reps)}</span>`;
-    }).join('')}
-                    </div>
-                `;
-
-                if (!inProgressExercise) {
-                    const useLastBtn = document.createElement('button');
-                    useLastBtn.type = 'button';
-                    useLastBtn.className = 'btn btn-secondary btn-sm';
-                    useLastBtn.textContent = '📋 Usar valores anteriores';
-                    useLastBtn.style.marginTop = '8px';
-                    useLastBtn.addEventListener('click', () => {
-                        fillExerciseWithLastValues(exerciseIndex, suggestions.suggestions.lastSets);
-                    });
-                    lastWorkoutInfo.appendChild(useLastBtn);
+            const buildVariantSuffix = (executionMode, loadType) => {
+                const variantLabels = [];
+                if (executionMode !== DEFAULT_EXECUTION_MODE) {
+                    variantLabels.push(getExecutionModeLabel(executionMode));
+                }
+                if (loadType !== DEFAULT_LOAD_TYPE) {
+                    variantLabels.push(getLoadTypeLabel(loadType));
                 }
 
-                exerciseBlock.appendChild(lastWorkoutInfo);
-            } else {
+                return variantLabels.length > 0 ? ' (' + variantLabels.join(', ') + ')' : '';
+            };
+            const getSuggestionsForVariant = (executionMode, loadType) => exerciseCache.getExerciseSuggestions(
+                exercise.name,
+                executionMode,
+                loadType
+            );
+            let suggestions = getSuggestionsForVariant(initialExecutionMode, initialLoadType);
+            const historyInfoContainer = document.createElement('div');
+            exerciseBlock.appendChild(historyInfoContainer);
+
+            const renderHistoryInfo = (suggestionsData, allowSignedLoad, variantSuffix) => {
+                historyInfoContainer.innerHTML = '';
+
+                if (suggestionsData.hasHistory) {
+                    const lastWorkoutInfo = document.createElement('div');
+                    lastWorkoutInfo.className = 'last-workout-info';
+
+                    const daysAgo = suggestionsData.daysSinceLastSession;
+                    const timeText = daysAgo === 0 ? 'hoy'
+                        : daysAgo === 1 ? 'ayer'
+                            : 'hace ' + daysAgo + ' d\u00EDas';
+
+                    const header = document.createElement('div');
+                    header.className = 'last-workout-header';
+                    const titleElement = document.createElement('span');
+                    titleElement.className = 'last-workout-title';
+                    titleElement.textContent = '\u00DAltimo entrenamiento' + variantSuffix;
+                    const timeElement = document.createElement('span');
+                    timeElement.className = 'workout-time-ago';
+                    timeElement.textContent = timeText;
+                    header.appendChild(titleElement);
+                    header.appendChild(timeElement);
+
+                    const details = document.createElement('div');
+                    details.className = 'last-workout-details';
+                    suggestionsData.suggestions.lastSets.forEach((set, idx) => {
+                        const loadValue = allowSignedLoad
+                            ? formatSignedWeight(set.peso) + 'kg extra'
+                            : set.peso + 'kg';
+                        const detail = document.createElement('span');
+                        detail.className = 'last-set';
+                        detail.textContent = 'S' + (idx + 1) + ': ' + loadValue + ' \u00D7 ' + set.reps;
+                        details.appendChild(detail);
+                    });
+
+                    lastWorkoutInfo.appendChild(header);
+                    lastWorkoutInfo.appendChild(details);
+
+                    if (!inProgressExercise) {
+                        const useLastBtn = document.createElement('button');
+                        useLastBtn.type = 'button';
+                        useLastBtn.className = 'btn btn-secondary btn-sm';
+                        useLastBtn.textContent = '\uD83D\uDCCB Usar valores anteriores';
+                        useLastBtn.style.marginTop = '8px';
+                        useLastBtn.addEventListener('click', () => {
+                            fillExerciseWithLastValues(exerciseIndex, suggestionsData.suggestions.lastSets);
+                        });
+                        lastWorkoutInfo.appendChild(useLastBtn);
+                    }
+
+                    historyInfoContainer.appendChild(lastWorkoutInfo);
+                    return;
+                }
+
                 const noHistoryInfo = document.createElement('div');
                 noHistoryInfo.className = 'no-exercise-history';
-                noHistoryInfo.textContent = '💡 Primera vez haciendo este ejercicio. ¡Registra tus datos para futuras referencias!';
-                exerciseBlock.appendChild(noHistoryInfo);
-            }
+                noHistoryInfo.textContent = '\uD83D\uDCA1 Primera vez haciendo este ejercicio. \u00A1Registra tus datos para futuras referencias!';
+                historyInfoContainer.appendChild(noHistoryInfo);
+            };
 
             const bodyweightInfo = document.createElement('p');
             bodyweightInfo.className = 'target-info session-bodyweight-hint';
@@ -622,7 +633,7 @@ export async function renderSessionView(routine, inProgressData = null) {
                 weightInput.placeholder = formatWeightSuggestionPlaceholder(
                     suggestionWeight,
                     placeholderType,
-                    allowsSignedLoadInSuggestion
+                    initialLoadType === 'bodyweight'
                 );
                 weightInput.inputMode = 'decimal';
                 weightInput.pattern = initialLoadType === 'bodyweight'
@@ -709,25 +720,69 @@ export async function renderSessionView(routine, inProgressData = null) {
                 const selectedLoadType = normalizeLoadType(loadTypeSelect.value);
                 exerciseBlock.dataset.executionMode = selectedExecutionMode;
                 exerciseBlock.dataset.loadType = selectedLoadType;
+                const allowSignedLoad = selectedLoadType === 'bodyweight';
+                suggestions = getSuggestionsForVariant(selectedExecutionMode, selectedLoadType);
+                renderHistoryInfo(
+                    suggestions,
+                    allowSignedLoad,
+                    buildVariantSuffix(selectedExecutionMode, selectedLoadType)
+                );
 
-                if (selectedLoadType === 'bodyweight') {
+                if (allowSignedLoad) {
                     bodyweightInfo.classList.remove('hidden');
                 } else {
                     bodyweightInfo.classList.add('hidden');
                 }
 
                 const weightInputs = exerciseBlock.querySelectorAll('input[name^="weight-"]');
-                weightInputs.forEach((weightInput) => {
-                    const allowSignedLoad = selectedLoadType === 'bodyweight';
+                weightInputs.forEach((weightInput, setIndex) => {
+                    let placeholderType = 'default';
+                    let suggestionWeight = null;
+                    const lastSetSuggestion = suggestions.hasHistory
+                        ? suggestions.suggestions.lastSets[setIndex]
+                        : null;
+
+                    if (lastSetSuggestion && Number.isFinite(Number(lastSetSuggestion.peso))) {
+                        placeholderType = 'last';
+                        suggestionWeight = Number(lastSetSuggestion.peso);
+                    } else if (suggestions.hasHistory && Number.isFinite(Number(suggestions.suggestions.peso))) {
+                        placeholderType = 'suggested';
+                        suggestionWeight = Number(suggestions.suggestions.peso);
+                    }
+
+                    if (Number.isFinite(suggestionWeight)) {
+                        weightInput.dataset.suggestion = String(suggestionWeight);
+                    } else {
+                        delete weightInput.dataset.suggestion;
+                    }
+                    weightInput.dataset.placeholderType = placeholderType;
                     weightInput.pattern = allowSignedLoad
                         ? '[+-]?[0-9]*[.,]?[0-9]*'
                         : '[0-9]*[.,]?[0-9]*';
                     weightInput.placeholder = formatWeightSuggestionPlaceholder(
-                        weightInput.dataset.suggestion,
-                        weightInput.dataset.placeholderType,
+                        suggestionWeight,
+                        placeholderType,
                         allowSignedLoad
                     );
                     weightInput.value = sanitizeWeightInputValue(weightInput.value, allowSignedLoad);
+                });
+
+                const repsInputs = exerciseBlock.querySelectorAll('input[name^="reps-"]');
+                repsInputs.forEach((repsInput, setIndex) => {
+                    let repsPlaceholder = 'Reps';
+                    delete repsInput.dataset.suggestion;
+                    const lastSetSuggestion = suggestions.hasHistory
+                        ? suggestions.suggestions.lastSets[setIndex]
+                        : null;
+
+                    if (lastSetSuggestion && lastSetSuggestion.reps > 0) {
+                        repsPlaceholder = `\u00DAltimo: ${lastSetSuggestion.reps}`;
+                        repsInput.dataset.suggestion = String(lastSetSuggestion.reps);
+                    } else if (suggestions.hasHistory && suggestions.suggestions.reps > 0) {
+                        repsPlaceholder = `Sugerido: ${suggestions.suggestions.reps}`;
+                        repsInput.dataset.suggestion = String(suggestions.suggestions.reps);
+                    }
+                    repsInput.placeholder = repsPlaceholder;
                 });
             };
 

--- a/js/utils/session-variant-overrides.js
+++ b/js/utils/session-variant-overrides.js
@@ -34,7 +34,11 @@ function writeSessionVariantOverrides(userId, overridesMap) {
         return;
     }
 
-    storage.setItem(storageKey, JSON.stringify(overridesMap));
+    try {
+        storage.setItem(storageKey, JSON.stringify(overridesMap));
+    } catch {
+        // Ignore storage write failures (e.g. quota/privacy mode) to avoid blocking session flows.
+    }
 }
 
 export function buildSessionVariantOverridesStorageKey(userId) {
@@ -65,7 +69,13 @@ export function readSessionVariantOverrides(userId) {
         return {};
     }
 
-    const raw = storage.getItem(storageKey);
+    let raw = null;
+    try {
+        raw = storage.getItem(storageKey);
+    } catch {
+        return {};
+    }
+
     if (!raw) {
         return {};
     }

--- a/js/utils/session-variant-overrides.js
+++ b/js/utils/session-variant-overrides.js
@@ -1,0 +1,158 @@
+import { normalizeExecutionMode } from './execution-mode.js';
+import { normalizeLoadType } from './load-type.js';
+
+const STORAGE_PREFIX = 'gym-tracker:session-variant-overrides:';
+const KEY_SEPARATOR = '::';
+
+function normalizeExerciseIdentity(exerciseName = '') {
+    return String(exerciseName || '')
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, ' ');
+}
+
+function sanitizeOverrideEntry(entry = {}) {
+    return {
+        executionMode: normalizeExecutionMode(entry.executionMode),
+        loadType: normalizeLoadType(entry.loadType)
+    };
+}
+
+function getSafeLocalStorage() {
+    if (typeof localStorage === 'undefined') {
+        return null;
+    }
+
+    return localStorage;
+}
+
+function writeSessionVariantOverrides(userId, overridesMap) {
+    const storage = getSafeLocalStorage();
+    const storageKey = buildSessionVariantOverridesStorageKey(userId);
+
+    if (!storage || !storageKey) {
+        return;
+    }
+
+    storage.setItem(storageKey, JSON.stringify(overridesMap));
+}
+
+export function buildSessionVariantOverridesStorageKey(userId) {
+    const normalizedUserId = String(userId || '').trim();
+    if (!normalizedUserId) {
+        return null;
+    }
+
+    return `${STORAGE_PREFIX}${normalizedUserId}`;
+}
+
+export function buildSessionVariantOverrideMapKey(routineId, exerciseName) {
+    const normalizedRoutineId = String(routineId || '').trim();
+    const normalizedExerciseName = normalizeExerciseIdentity(exerciseName);
+
+    if (!normalizedRoutineId || !normalizedExerciseName) {
+        return null;
+    }
+
+    return `${normalizedRoutineId}${KEY_SEPARATOR}${normalizedExerciseName}`;
+}
+
+export function readSessionVariantOverrides(userId) {
+    const storage = getSafeLocalStorage();
+    const storageKey = buildSessionVariantOverridesStorageKey(userId);
+
+    if (!storage || !storageKey) {
+        return {};
+    }
+
+    const raw = storage.getItem(storageKey);
+    if (!raw) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? parsed
+            : {};
+    } catch {
+        return {};
+    }
+}
+
+export function getSessionVariantOverride(userId, routineId, exerciseName) {
+    const mapKey = buildSessionVariantOverrideMapKey(routineId, exerciseName);
+    if (!mapKey) {
+        return null;
+    }
+
+    const overrides = readSessionVariantOverrides(userId);
+    if (!overrides[mapKey]) {
+        return null;
+    }
+
+    return sanitizeOverrideEntry(overrides[mapKey]);
+}
+
+export function saveSessionVariantOverride(userId, routineId, exerciseName, override = {}) {
+    return saveSessionVariantOverrides(userId, [{
+        routineId,
+        exerciseName,
+        executionMode: override.executionMode,
+        loadType: override.loadType
+    }]);
+}
+
+export function saveSessionVariantOverrides(userId, overrides = []) {
+    if (!Array.isArray(overrides) || overrides.length === 0) {
+        return readSessionVariantOverrides(userId);
+    }
+
+    const existing = readSessionVariantOverrides(userId);
+
+    overrides.forEach((override) => {
+        const mapKey = buildSessionVariantOverrideMapKey(
+            override?.routineId,
+            override?.exerciseName
+        );
+
+        if (!mapKey) {
+            return;
+        }
+
+        existing[mapKey] = sanitizeOverrideEntry({
+            executionMode: override.executionMode,
+            loadType: override.loadType
+        });
+    });
+
+    writeSessionVariantOverrides(userId, existing);
+    return existing;
+}
+
+export function resolveSessionVariantSelection({
+    inProgressExercise = null,
+    localOverride = null,
+    routineExercise = null
+} = {}) {
+    const executionMode = normalizeExecutionMode(
+        inProgressExercise?.modoEjecucion
+        ?? inProgressExercise?.executionMode
+        ?? localOverride?.executionMode
+        ?? routineExercise?.executionMode
+        ?? routineExercise?.modoEjecucion
+    );
+
+    const loadType = normalizeLoadType(
+        inProgressExercise?.tipoCarga
+        ?? inProgressExercise?.loadType
+        ?? localOverride?.loadType
+        ?? routineExercise?.loadType
+        ?? routineExercise?.tipoCarga
+    );
+
+    return {
+        executionMode,
+        loadType
+    };
+}

--- a/js/utils/session-variant-overrides.js
+++ b/js/utils/session-variant-overrides.js
@@ -4,7 +4,7 @@ import { normalizeLoadType } from './load-type.js';
 const STORAGE_PREFIX = 'gym-tracker:session-variant-overrides:';
 const KEY_SEPARATOR = '::';
 
-function normalizeExerciseIdentity(exerciseName = '') {
+export function normalizeExerciseIdentity(exerciseName = '') {
     return String(exerciseName || '')
         .trim()
         .toLowerCase()

--- a/tests/integration/app-offline-recovery.test.js
+++ b/tests/integration/app-offline-recovery.test.js
@@ -201,6 +201,8 @@ describe('App Offline Recovery Journey', () => {
         await waitForUi(250);
 
         expect(isVisible('session-view')).toBe(true);
+        setField('select[name="session-execution-mode"]', 'machine');
+        setField('select[name="session-load-type"]', 'bodyweight');
         setField('input[name="weight-0-0"]', '65');
         setField('input[name="reps-0-0"]', '8');
         await waitForUi(150);
@@ -221,7 +223,8 @@ describe('App Offline Recovery Journey', () => {
         expect(savedAfterReconnect).toHaveLength(2);
         const routineSession = savedAfterReconnect.find((entry) => entry.data.nombreEntrenamiento === 'Offline Test Routine');
         expect(routineSession).toBeDefined();
-        expect(routineSession.data.ejercicios[0].modoEjecucion).toBe('pulley');
+        expect(routineSession.data.ejercicios[0].modoEjecucion).toBe('machine');
+        expect(routineSession.data.ejercicios[0].tipoCarga).toBe('bodyweight');
         expect(offlineManager.getPendingCount()).toBe(0);
 
         click('#nav-history');

--- a/tests/integration/app-offline-retry.test.js
+++ b/tests/integration/app-offline-retry.test.js
@@ -206,6 +206,8 @@ describe('App Offline Retry Journey', () => {
         click('#start-session-btn');
         await waitForUi(200);
 
+        setField('select[name="session-execution-mode"]', 'one_hand');
+        setField('select[name="session-load-type"]', 'bodyweight');
         setField('input[name="weight-0-0"]', '67.5');
         setField('input[name="reps-0-0"]', '7');
         await waitForUi(100);
@@ -234,7 +236,8 @@ describe('App Offline Retry Journey', () => {
         expect(savedSessions).toHaveLength(2);
         const sessionEntry = savedSessions.find((entry) => entry.data.nombreEntrenamiento === 'Retry Routine');
         expect(sessionEntry).toBeDefined();
-        expect(sessionEntry.data.ejercicios[0].modoEjecucion).toBe('two_hand');
+        expect(sessionEntry.data.ejercicios[0].modoEjecucion).toBe('one_hand');
+        expect(sessionEntry.data.ejercicios[0].tipoCarga).toBe('bodyweight');
         expect(offlineManager.getPendingCount()).toBe(0);
     }, 45000);
 

--- a/tests/unit/session-manager.test.js
+++ b/tests/unit/session-manager.test.js
@@ -155,6 +155,39 @@ function setupRoutineFormValues() {
     `;
 }
 
+function setupRoutineFormValuesWithSessionVariants({
+    executionMode = 'machine',
+    loadType = 'bodyweight',
+    weight = '-10',
+    reps = '8'
+} = {}) {
+    sessionElements.exerciseList.innerHTML = `
+        <div class="exercise-block" data-exercise-index="0">
+            <select name="session-execution-mode">
+                <option value="one_hand">Una mano</option>
+                <option value="two_hand">Dos manos</option>
+                <option value="machine">Maquina</option>
+                <option value="pulley">Polea</option>
+                <option value="other">Otro</option>
+            </select>
+            <select name="session-load-type">
+                <option value="external">Carga externa</option>
+                <option value="bodyweight">Peso corporal (+/-)</option>
+            </select>
+            <div class="set-row">
+                <input name="weight-0-0" value="${weight}" />
+                <input name="reps-0-0" value="${reps}" />
+                <span id="timer-display-0-0">01:30</span>
+                <button class="timer-button" type="button">Timer</button>
+            </div>
+            <textarea name="notes-0">Con variantes</textarea>
+        </div>
+    `;
+
+    sessionElements.exerciseList.querySelector('select[name="session-execution-mode"]').value = executionMode;
+    sessionElements.exerciseList.querySelector('select[name="session-load-type"]').value = loadType;
+}
+
 describe('Session Manager', () => {
     const user = { uid: 'session-user-1' };
     const routine = {
@@ -246,6 +279,21 @@ describe('Session Manager', () => {
         });
     });
 
+    it('getSessionFormData uses selected session variants over routine defaults', () => {
+        setCurrentRoutineForSession(routine);
+        setupRoutineFormValuesWithSessionVariants({
+            executionMode: 'machine',
+            loadType: 'bodyweight',
+            weight: '-12',
+            reps: '6'
+        });
+
+        const formData = getSessionFormData();
+        expect(formData.ejercicios[0].modoEjecucion).toBe('machine');
+        expect(formData.ejercicios[0].tipoCarga).toBe('bodyweight');
+        expect(formData.ejercicios[0].sets[0].peso).toBe(-12);
+    });
+
     it('saveSessionData saves to Firestore, clears state and calls success callback', async () => {
         setCurrentRoutineForSession(routine);
         document.getElementById('user-weight').value = '74,9';
@@ -283,6 +331,27 @@ describe('Session Manager', () => {
         expect(onSuccess).toHaveBeenCalled();
         expect(mockShowLoading).toHaveBeenCalled();
         expect(mockHideLoading).toHaveBeenCalled();
+    });
+
+    it('saveSessionData remembers selected variants in local override storage', async () => {
+        setCurrentRoutineForSession(routine);
+        setupRoutineFormValuesWithSessionVariants({
+            executionMode: 'pulley',
+            loadType: 'bodyweight',
+            weight: '10',
+            reps: '8'
+        });
+
+        await saveSessionData();
+
+        const savedOverrides = JSON.parse(
+            localStorage.getItem(`gym-tracker:session-variant-overrides:${user.uid}`)
+        );
+
+        expect(savedOverrides['routine-1::bench press']).toEqual({
+            executionMode: 'pulley',
+            loadType: 'bodyweight'
+        });
     });
 
     it('saveQuickLogEntry saves a quick log session and clears caches', async () => {

--- a/tests/unit/session-manager.test.js
+++ b/tests/unit/session-manager.test.js
@@ -553,4 +553,26 @@ describe('Session Manager', () => {
         });
         expect(stored.data.ejercicios[0].sets).toHaveLength(0);
     });
+
+    it('setupSessionAutoSave keeps variant-only snapshot when timer auto-save runs', async () => {
+        setCurrentRoutineForSession(routine);
+        setupRoutineFormVariantOnlyValues({
+            executionMode: 'machine',
+            loadType: 'bodyweight'
+        });
+        setupSessionAutoSave();
+
+        const timerButton = sessionElements.exerciseList.querySelector('.timer-button');
+        timerButton.dispatchEvent(new Event('click', { bubbles: true }));
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        const stored = JSON.parse(localStorage.getItem(IN_PROGRESS_SESSION_KEY));
+        expect(stored.routineId).toBe('routine-1');
+        expect(stored.data.ejercicios).toHaveLength(1);
+        expect(stored.data.ejercicios[0]).toMatchObject({
+            nombreEjercicio: 'Bench Press',
+            modoEjecucion: 'machine',
+            tipoCarga: 'bodyweight'
+        });
+    });
 });

--- a/tests/unit/session-manager.test.js
+++ b/tests/unit/session-manager.test.js
@@ -188,6 +188,37 @@ function setupRoutineFormValuesWithSessionVariants({
     sessionElements.exerciseList.querySelector('select[name="session-load-type"]').value = loadType;
 }
 
+function setupRoutineFormVariantOnlyValues({
+    executionMode = 'machine',
+    loadType = 'bodyweight'
+} = {}) {
+    sessionElements.exerciseList.innerHTML = `
+        <div class="exercise-block" data-exercise-index="0">
+            <select name="session-execution-mode">
+                <option value="one_hand">Una mano</option>
+                <option value="two_hand">Dos manos</option>
+                <option value="machine">Maquina</option>
+                <option value="pulley">Polea</option>
+                <option value="other">Otro</option>
+            </select>
+            <select name="session-load-type">
+                <option value="external">Carga externa</option>
+                <option value="bodyweight">Peso corporal (+/-)</option>
+            </select>
+            <div class="set-row">
+                <input name="weight-0-0" value="" />
+                <input name="reps-0-0" value="" />
+                <span id="timer-display-0-0">00:00</span>
+                <button class="timer-button" type="button">Timer</button>
+            </div>
+            <textarea name="notes-0"></textarea>
+        </div>
+    `;
+
+    sessionElements.exerciseList.querySelector('select[name="session-execution-mode"]').value = executionMode;
+    sessionElements.exerciseList.querySelector('select[name="session-load-type"]').value = loadType;
+}
+
 describe('Session Manager', () => {
     const user = { uid: 'session-user-1' };
     const routine = {
@@ -354,6 +385,32 @@ describe('Session Manager', () => {
         });
     });
 
+    it('saveSessionData remembers selected variants even when session save is queued offline', async () => {
+        setCurrentRoutineForSession(routine);
+        setupRoutineFormValuesWithSessionVariants({
+            executionMode: 'machine',
+            loadType: 'bodyweight',
+            weight: '8',
+            reps: '8'
+        });
+        mockExecuteWithOfflineHandling.mockImplementation(async () => {
+            throw new Error('Offline: queued');
+        });
+
+        await saveSessionData();
+
+        const savedOverrides = JSON.parse(
+            localStorage.getItem(`gym-tracker:session-variant-overrides:${user.uid}`)
+        );
+
+        expect(savedOverrides['routine-1::bench press']).toEqual({
+            executionMode: 'machine',
+            loadType: 'bodyweight'
+        });
+        expect(mockToastInfo).toHaveBeenCalled();
+        expect(__firestoreState.documents.size).toBe(0);
+    });
+
     it('saveQuickLogEntry saves a quick log session and clears caches', async () => {
         const onSuccess = jest.fn();
         const result = await saveQuickLogEntry(
@@ -474,5 +531,26 @@ describe('Session Manager', () => {
         const stored = JSON.parse(localStorage.getItem(IN_PROGRESS_SESSION_KEY));
         expect(stored.routineId).toBe('routine-1');
         expect(stored.data.ejercicios).toHaveLength(1);
+    });
+
+    it('setupSessionAutoSave preserves variant-only changes in in-progress snapshots', () => {
+        setCurrentRoutineForSession(routine);
+        setupRoutineFormVariantOnlyValues({
+            executionMode: 'pulley',
+            loadType: 'bodyweight'
+        });
+        setupSessionAutoSave();
+
+        sessionElements.exerciseList.dispatchEvent(new Event('change', { bubbles: true }));
+
+        const stored = JSON.parse(localStorage.getItem(IN_PROGRESS_SESSION_KEY));
+        expect(stored.routineId).toBe('routine-1');
+        expect(stored.data.ejercicios).toHaveLength(1);
+        expect(stored.data.ejercicios[0]).toMatchObject({
+            nombreEjercicio: 'Bench Press',
+            modoEjecucion: 'pulley',
+            tipoCarga: 'bodyweight'
+        });
+        expect(stored.data.ejercicios[0].sets).toHaveLength(0);
     });
 });

--- a/tests/unit/session-variant-overrides.test.js
+++ b/tests/unit/session-variant-overrides.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import {
     buildSessionVariantOverridesStorageKey,
     buildSessionVariantOverrideMapKey,
@@ -124,5 +124,33 @@ describe('session-variant-overrides utils', () => {
             executionMode: 'two_hand',
             loadType: 'external'
         });
+    });
+
+    it('returns an empty map when localStorage read fails', () => {
+        const getItemSpy = jest
+            .spyOn(Storage.prototype, 'getItem')
+            .mockImplementation(() => {
+                throw new Error('Storage blocked');
+            });
+
+        expect(readSessionVariantOverrides('user-1')).toEqual({});
+        expect(getSessionVariantOverride('user-1', 'routine-1', 'Bench Press')).toBeNull();
+
+        getItemSpy.mockRestore();
+    });
+
+    it('does not throw when localStorage write fails', () => {
+        const setItemSpy = jest
+            .spyOn(Storage.prototype, 'setItem')
+            .mockImplementation(() => {
+                throw new Error('Quota exceeded');
+            });
+
+        expect(() => saveSessionVariantOverride('user-1', 'routine-1', 'Bench Press', {
+            executionMode: 'machine',
+            loadType: 'external'
+        })).not.toThrow();
+
+        setItemSpy.mockRestore();
     });
 });

--- a/tests/unit/session-variant-overrides.test.js
+++ b/tests/unit/session-variant-overrides.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+    buildSessionVariantOverridesStorageKey,
+    buildSessionVariantOverrideMapKey,
+    readSessionVariantOverrides,
+    getSessionVariantOverride,
+    saveSessionVariantOverride,
+    saveSessionVariantOverrides,
+    resolveSessionVariantSelection
+} from '../../js/utils/session-variant-overrides.js';
+
+describe('session-variant-overrides utils', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('builds the expected storage key per user id', () => {
+        expect(buildSessionVariantOverridesStorageKey('user-123')).toBe(
+            'gym-tracker:session-variant-overrides:user-123'
+        );
+        expect(buildSessionVariantOverridesStorageKey('')).toBeNull();
+        expect(buildSessionVariantOverridesStorageKey(null)).toBeNull();
+    });
+
+    it('builds normalized map keys for routine and exercise identity', () => {
+        expect(buildSessionVariantOverrideMapKey('routine-a', '  Bench   Press ')).toBe('routine-a::bench press');
+        expect(buildSessionVariantOverrideMapKey('', 'Bench Press')).toBeNull();
+        expect(buildSessionVariantOverrideMapKey('routine-a', '')).toBeNull();
+    });
+
+    it('saves and reads a single override entry', () => {
+        saveSessionVariantOverride('user-1', 'routine-1', 'Bench Press', {
+            executionMode: 'PULLEY',
+            loadType: 'BODYWEIGHT'
+        });
+
+        const saved = getSessionVariantOverride('user-1', 'routine-1', 'bench press');
+        expect(saved).toEqual({
+            executionMode: 'pulley',
+            loadType: 'bodyweight'
+        });
+
+        const raw = readSessionVariantOverrides('user-1');
+        expect(raw['routine-1::bench press']).toMatchObject({
+            executionMode: 'pulley',
+            loadType: 'bodyweight'
+        });
+    });
+
+    it('saves override batches and normalizes invalid values to defaults', () => {
+        const updated = saveSessionVariantOverrides('user-2', [
+            {
+                routineId: 'routine-2',
+                exerciseName: 'Pull Up',
+                executionMode: 'one_hand',
+                loadType: 'bodyweight'
+            },
+            {
+                routineId: 'routine-2',
+                exerciseName: 'Incline Press',
+                executionMode: 'invalid-mode',
+                loadType: 'invalid-load-type'
+            }
+        ]);
+
+        expect(updated['routine-2::pull up']).toEqual({
+            executionMode: 'one_hand',
+            loadType: 'bodyweight'
+        });
+        expect(updated['routine-2::incline press']).toEqual({
+            executionMode: 'two_hand',
+            loadType: 'external'
+        });
+    });
+
+    it('resolves selection precedence as in-progress > local override > routine default', () => {
+        const resolvedWithInProgress = resolveSessionVariantSelection({
+            inProgressExercise: {
+                modoEjecucion: 'machine',
+                tipoCarga: 'bodyweight'
+            },
+            localOverride: {
+                executionMode: 'pulley',
+                loadType: 'external'
+            },
+            routineExercise: {
+                executionMode: 'two_hand',
+                loadType: 'external'
+            }
+        });
+
+        expect(resolvedWithInProgress).toEqual({
+            executionMode: 'machine',
+            loadType: 'bodyweight'
+        });
+
+        const resolvedWithLocal = resolveSessionVariantSelection({
+            inProgressExercise: null,
+            localOverride: {
+                executionMode: 'one_hand',
+                loadType: 'bodyweight'
+            },
+            routineExercise: {
+                executionMode: 'pulley',
+                loadType: 'external'
+            }
+        });
+
+        expect(resolvedWithLocal).toEqual({
+            executionMode: 'one_hand',
+            loadType: 'bodyweight'
+        });
+
+        const resolvedWithDefaults = resolveSessionVariantSelection({
+            inProgressExercise: null,
+            localOverride: null,
+            routineExercise: {
+                executionMode: 'invalid',
+                loadType: 'invalid'
+            }
+        });
+
+        expect(resolvedWithDefaults).toEqual({
+            executionMode: 'two_hand',
+            loadType: 'external'
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Implements the PR-first workflow documentation and starts Phase 1 of the next major feature (`Session-Time Exercise Variants + ES/EN`) with the `Variants First` scope.

### Docs and Process

- Added `CONTRIBUTING.md` as the primary workflow policy doc.
- Updated `README.md` with a concise major-feature shipping section and link to `CONTRIBUTING.md`.
- Reworked `.github/PULL_REQUEST_TEMPLATE.md` to support long-lived major-feature PR lifecycle and gate tracking.

### Feature Work (Phase 1)

- Added per-exercise Session view controls:
  - `name="session-execution-mode"`
  - `name="session-load-type"`
- Added precedence resolution for session variant values:
  - in-progress snapshot > local override > routine default
- Added local override persistence:
  - key: `gym-tracker:session-variant-overrides:<userId>`
  - map key: `<routineId>::<normalizedExerciseName>`
  - value: `{ executionMode, loadType }`
- Ensured saved session payload continues using existing fields:
  - `modoEjecucion`
  - `tipoCarga`
- Kept offline queue/replay behavior unchanged.

### Tests

- Added unit tests for local override storage and precedence resolution.
- Updated session-manager unit coverage for selected session variant controls and local persistence.
- Updated offline recovery/retry integration journeys to verify selected variants survive queue/replay.

## Validation

- `npm run lint:ratchet`
- `npm run test:app`
- `npm run test:app:offline`
- `npm run test:no-skips`
- `npm run test:coverage:gate`

All passed locally.
