### PR TITLE
Fix dashboard calendar back-navigation lower bound

### DIFF
--- a/js/modules/calendar.js
+++ b/js/modules/calendar.js
@@ -4,7 +4,7 @@
  */
 
 import { db } from '../firebase-config.js';
-import { collection, query, where, getDocs, Timestamp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
+import { collection, query, where, orderBy, limit, getDocs, Timestamp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
 import { getCurrentUser } from '../auth.js';
 import { logger } from '../utils/logger.js';
 import { debounce } from '../utils/debounce.js';
@@ -15,6 +15,7 @@ import { serializeActivityMap, deserializeActivityMap } from '../utils/firestore
 import { t, getLocale } from '../i18n.js';
 
 // Constants
+// Legacy export kept for compatibility with older integrations/tests.
 const MIN_CALENDAR_YEAR = 2025;
 const CALENDAR_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 
@@ -22,6 +23,11 @@ const CALENDAR_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 let currentCalendarYear = new Date().getFullYear();
 let currentCalendarMonth = new Date().getMonth(); // 0-11 (enero-diciembre)
 let isInitialized = false;
+let minimumBoundUserId = null;
+let minimumBoundYear = null;
+let minimumBoundMonth = null;
+let minimumBoundResolved = false;
+let minimumBoundPermissive = false;
 
 // DOM element references
 let calendarContainer = null;
@@ -101,6 +107,105 @@ function combineWorkoutTypes(type1, type2) {
  */
 function getDaysInMonth(year, month) {
     return new Date(year, month + 1, 0).getDate();
+}
+
+function compareCalendarMonth(yearA, monthA, yearB, monthB) {
+    if (yearA < yearB) return -1;
+    if (yearA > yearB) return 1;
+    if (monthA < monthB) return -1;
+    if (monthA > monthB) return 1;
+    return 0;
+}
+
+function resetMinimumBoundState() {
+    minimumBoundUserId = null;
+    minimumBoundYear = null;
+    minimumBoundMonth = null;
+    minimumBoundResolved = false;
+    minimumBoundPermissive = false;
+}
+
+async function resolveMinimumBoundForUser(userId) {
+    if (!userId) {
+        resetMinimumBoundState();
+        return;
+    }
+
+    if (minimumBoundUserId !== userId) {
+        minimumBoundUserId = userId;
+        minimumBoundYear = null;
+        minimumBoundMonth = null;
+        minimumBoundResolved = false;
+        minimumBoundPermissive = false;
+    }
+
+    if (minimumBoundResolved || minimumBoundPermissive) {
+        return;
+    }
+
+    try {
+        const sessionsRef = collection(db, 'users', userId, 'sesiones_entrenamiento');
+        const earliestSessionQuery = query(
+            sessionsRef,
+            orderBy('fecha', 'asc'),
+            limit(1)
+        );
+        const querySnapshot = await getDocs(earliestSessionQuery);
+
+        if (querySnapshot.empty) {
+            const today = new Date();
+            minimumBoundYear = today.getFullYear();
+            minimumBoundMonth = today.getMonth();
+            minimumBoundResolved = true;
+            return;
+        }
+
+        const earliestSessionDate = querySnapshot.docs[0]?.data()?.fecha?.toDate?.();
+        if (earliestSessionDate instanceof Date && !Number.isNaN(earliestSessionDate.getTime())) {
+            minimumBoundYear = earliestSessionDate.getFullYear();
+            minimumBoundMonth = earliestSessionDate.getMonth();
+            minimumBoundResolved = true;
+            return;
+        }
+
+        logger.warn('Could not resolve earliest activity month due to invalid date payload.');
+        minimumBoundPermissive = true;
+    } catch (error) {
+        logger.warn('Could not resolve earliest activity month. Backward navigation will stay enabled:', error);
+        minimumBoundPermissive = true;
+    }
+}
+
+function clampCalendarToAllowedRange() {
+    const today = new Date();
+    const currentYear = today.getFullYear();
+    const currentMonth = today.getMonth();
+
+    // Guard against future navigation.
+    if (
+        currentCalendarYear > currentYear
+        || (currentCalendarYear === currentYear && currentCalendarMonth > currentMonth)
+    ) {
+        currentCalendarYear = currentYear;
+        currentCalendarMonth = currentMonth;
+    }
+
+    // When the lower bound cannot be resolved, keep backward navigation permissive.
+    if (!minimumBoundResolved || minimumBoundPermissive) {
+        return;
+    }
+
+    if (
+        compareCalendarMonth(
+            currentCalendarYear,
+            currentCalendarMonth,
+            minimumBoundYear,
+            minimumBoundMonth
+        ) < 0
+    ) {
+        currentCalendarYear = minimumBoundYear;
+        currentCalendarMonth = minimumBoundMonth;
+    }
 }
 
 /**
@@ -347,9 +452,14 @@ function updateCalendarNavigation() {
     const currentYear = today.getFullYear();
     const currentMonth = today.getMonth();
     
-    // Disable "prev" button if at minimum month/year
-    const isAtMinimum = (currentCalendarYear === MIN_CALENDAR_YEAR && currentCalendarMonth === 0) ||
-                       currentCalendarYear < MIN_CALENDAR_YEAR;
+    // Disable "prev" button only when the current view is exactly the lower bound month.
+    const hasResolvedBound = minimumBoundResolved
+        && Number.isInteger(minimumBoundYear)
+        && Number.isInteger(minimumBoundMonth);
+    const isAtMinimum = hasResolvedBound
+        && !minimumBoundPermissive
+        && currentCalendarYear === minimumBoundYear
+        && currentCalendarMonth === minimumBoundMonth;
     
     // Disable "next" button if at current month/year
     const isAtMaximum = (currentCalendarYear === currentYear && currentCalendarMonth >= currentMonth) ||
@@ -366,6 +476,7 @@ function updateCalendarNavigation() {
 async function updateCalendarViewInternal() {
     const user = getCurrentUser();
     if (!user) {
+        resetMinimumBoundState();
         if (calendarContainer) calendarContainer.classList.add('hidden');
         return;
     }
@@ -386,17 +497,8 @@ async function updateCalendarViewInternal() {
         return;
     }
     
-    // Ensure we don't go below minimum year
-    if (currentCalendarYear < MIN_CALENDAR_YEAR) {
-        currentCalendarYear = MIN_CALENDAR_YEAR;
-        currentCalendarMonth = 0; // January of minimum year
-    }
-    
-    // Validate that we don't go to a future month
-    const today = new Date();
-    if (currentCalendarYear === today.getFullYear() && currentCalendarMonth > today.getMonth()) {
-        currentCalendarMonth = today.getMonth();
-    }
+    await resolveMinimumBoundForUser(user.uid);
+    clampCalendarToAllowedRange();
     
     calendarContainer.classList.remove('hidden');
     
@@ -424,11 +526,19 @@ function navigateToPreviousMonth() {
         currentCalendarMonth = 11;
         currentCalendarYear--;
     }
-    
-    // Check limits
-    if (currentCalendarYear < MIN_CALENDAR_YEAR) {
-        currentCalendarYear = MIN_CALENDAR_YEAR;
-        currentCalendarMonth = 0;
+
+    if (!minimumBoundPermissive && minimumBoundResolved) {
+        if (
+            compareCalendarMonth(
+                currentCalendarYear,
+                currentCalendarMonth,
+                minimumBoundYear,
+                minimumBoundMonth
+            ) < 0
+        ) {
+            currentCalendarYear = minimumBoundYear;
+            currentCalendarMonth = minimumBoundMonth;
+        }
     }
     
     updateCalendarView();
@@ -497,13 +607,7 @@ export function resetToCurrentMonth() {
     const today = new Date();
     currentCalendarYear = today.getFullYear();
     currentCalendarMonth = today.getMonth();
-    
-    // Ensure not below minimum year
-    if (currentCalendarYear < MIN_CALENDAR_YEAR) {
-        currentCalendarYear = MIN_CALENDAR_YEAR;
-        currentCalendarMonth = 0;
-    }
-    
+
     updateCalendarView();
 }
 
@@ -527,6 +631,7 @@ export function destroyCalendar() {
     nextMonthBtn = null;
     loadingSpinner = null;
     isInitialized = false;
+    resetMinimumBoundState();
 
     logger.debug('Calendar module destroyed');
 }

--- a/js/modules/calendar.js
+++ b/js/modules/calendar.js
@@ -18,6 +18,7 @@ import { t, getLocale } from '../i18n.js';
 // Legacy export kept for compatibility with older integrations/tests.
 const MIN_CALENDAR_YEAR = 2025;
 const CALENDAR_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+const MINIMUM_BOUND_RETRY_MS = 5 * 60 * 1000;
 
 // State
 let currentCalendarYear = new Date().getFullYear();
@@ -28,6 +29,7 @@ let minimumBoundYear = null;
 let minimumBoundMonth = null;
 let minimumBoundResolved = false;
 let minimumBoundPermissive = false;
+let minimumBoundLastAttemptAt = 0;
 
 // DOM element references
 let calendarContainer = null;
@@ -109,6 +111,14 @@ function getDaysInMonth(year, month) {
     return new Date(year, month + 1, 0).getDate();
 }
 
+/**
+ * Compares two year-month pairs.
+ * @param {number} yearA - First year
+ * @param {number} monthA - First month (0-11)
+ * @param {number} yearB - Second year
+ * @param {number} monthB - Second month (0-11)
+ * @returns {number} -1 if A < B, 1 if A > B, 0 if equal
+ */
 function compareCalendarMonth(yearA, monthA, yearB, monthB) {
     if (yearA < yearB) return -1;
     if (yearA > yearB) return 1;
@@ -117,14 +127,23 @@ function compareCalendarMonth(yearA, monthA, yearB, monthB) {
     return 0;
 }
 
+/**
+ * Resets dynamic minimum-bound state for calendar navigation.
+ */
 function resetMinimumBoundState() {
     minimumBoundUserId = null;
     minimumBoundYear = null;
     minimumBoundMonth = null;
     minimumBoundResolved = false;
     minimumBoundPermissive = false;
+    minimumBoundLastAttemptAt = 0;
 }
 
+/**
+ * Resolves the earliest valid activity month for a user.
+ * Uses a permissive fallback on transient failures, with retry backoff.
+ * @param {string} userId - Authenticated user id
+ */
 async function resolveMinimumBoundForUser(userId) {
     if (!userId) {
         resetMinimumBoundState();
@@ -139,16 +158,23 @@ async function resolveMinimumBoundForUser(userId) {
         minimumBoundPermissive = false;
     }
 
-    if (minimumBoundResolved || minimumBoundPermissive) {
+    if (minimumBoundResolved) {
         return;
     }
+
+    const now = Date.now();
+    if (minimumBoundPermissive && (now - minimumBoundLastAttemptAt) < MINIMUM_BOUND_RETRY_MS) {
+        return;
+    }
+
+    minimumBoundLastAttemptAt = now;
 
     try {
         const sessionsRef = collection(db, 'users', userId, 'sesiones_entrenamiento');
         const earliestSessionQuery = query(
             sessionsRef,
             orderBy('fecha', 'asc'),
-            limit(1)
+            limit(10)
         );
         const querySnapshot = await getDocs(earliestSessionQuery);
         firebaseUsageTracker.trackRead(querySnapshot.docs.length || 1, 'calendar.minimumBound');
@@ -158,14 +184,36 @@ async function resolveMinimumBoundForUser(userId) {
             minimumBoundYear = today.getFullYear();
             minimumBoundMonth = today.getMonth();
             minimumBoundResolved = true;
+            minimumBoundPermissive = false;
             return;
         }
 
-        const earliestSessionDate = querySnapshot.docs[0]?.data()?.fecha?.toDate?.();
-        if (earliestSessionDate instanceof Date && !Number.isNaN(earliestSessionDate.getTime())) {
+        const earliestSessionDate = querySnapshot.docs
+            .map((docSnap) => docSnap?.data?.()?.fecha?.toDate?.())
+            .find((date) => date instanceof Date && !Number.isNaN(date.getTime()));
+
+        if (earliestSessionDate) {
             minimumBoundYear = earliestSessionDate.getFullYear();
             minimumBoundMonth = earliestSessionDate.getMonth();
+
+            const today = new Date();
+            const currentYear = today.getFullYear();
+            const currentMonth = today.getMonth();
+            if (
+                compareCalendarMonth(
+                    minimumBoundYear,
+                    minimumBoundMonth,
+                    currentYear,
+                    currentMonth
+                ) > 0
+            ) {
+                logger.warn('Resolved earliest activity month is in the future. Clamping lower bound to current month.');
+                minimumBoundYear = currentYear;
+                minimumBoundMonth = currentMonth;
+            }
+
             minimumBoundResolved = true;
+            minimumBoundPermissive = false;
             return;
         }
 
@@ -177,6 +225,9 @@ async function resolveMinimumBoundForUser(userId) {
     }
 }
 
+/**
+ * Clamps current calendar state to valid navigation bounds.
+ */
 function clampCalendarToAllowedRange() {
     const today = new Date();
     const currentYear = today.getFullYear();
@@ -196,16 +247,31 @@ function clampCalendarToAllowedRange() {
         return;
     }
 
+    let effectiveMinimumBoundYear = minimumBoundYear;
+    let effectiveMinimumBoundMonth = minimumBoundMonth;
+    if (
+        compareCalendarMonth(
+            effectiveMinimumBoundYear,
+            effectiveMinimumBoundMonth,
+            currentYear,
+            currentMonth
+        ) > 0
+    ) {
+        logger.warn('Resolved earliest activity month is in the future. Clamping lower bound to current month.');
+        effectiveMinimumBoundYear = currentYear;
+        effectiveMinimumBoundMonth = currentMonth;
+    }
+
     if (
         compareCalendarMonth(
             currentCalendarYear,
             currentCalendarMonth,
-            minimumBoundYear,
-            minimumBoundMonth
+            effectiveMinimumBoundYear,
+            effectiveMinimumBoundMonth
         ) < 0
     ) {
-        currentCalendarYear = minimumBoundYear;
-        currentCalendarMonth = minimumBoundMonth;
+        currentCalendarYear = effectiveMinimumBoundYear;
+        currentCalendarMonth = effectiveMinimumBoundMonth;
     }
 }
 

--- a/js/modules/calendar.js
+++ b/js/modules/calendar.js
@@ -151,6 +151,7 @@ async function resolveMinimumBoundForUser(userId) {
             limit(1)
         );
         const querySnapshot = await getDocs(earliestSessionQuery);
+        firebaseUsageTracker.trackRead(querySnapshot.docs.length || 1, 'calendar.minimumBound');
 
         if (querySnapshot.empty) {
             const today = new Date();

--- a/tests/unit/calendar.test.js
+++ b/tests/unit/calendar.test.js
@@ -14,6 +14,7 @@ const mockCacheSet = jest.fn();
 const mockTrackRead = jest.fn();
 const mockSerializeActivityMap = jest.fn((map) => Array.from(map.entries()));
 const mockDeserializeActivityMap = jest.fn((entries) => new Map(entries));
+const MINIMUM_BOUND_RETRY_MS = 5 * 60 * 1000;
 
 let calendarClickHandler = null;
 const mockAddViewListener = jest.fn((_view, _element, _event, handler) => {
@@ -301,6 +302,48 @@ describe('Calendar module', () => {
         expect(getCalendarState()).toEqual(minimumState);
     });
 
+    it('uses first valid earliest date when older docs have invalid fecha payloads', async () => {
+        const today = new Date();
+        const earliestActivityDate = new Date(today.getFullYear(), today.getMonth(), 10);
+        earliestActivityDate.setMonth(earliestActivityDate.getMonth() - 2);
+
+        __firestoreState.documents.set(
+            `users/${user.uid}/sesiones_entrenamiento/session-invalid-first`,
+            {
+                fecha: null,
+                ejercicios: [{ tipoEjercicio: 'strength' }]
+            }
+        );
+        seedSession({
+            userId: user.uid,
+            id: 'session-valid-earliest',
+            date: earliestActivityDate,
+            tipos: ['strength']
+        });
+
+        initCalendar();
+        resetToCurrentMonth();
+        await flushDebounce();
+
+        for (let i = 0; i < 60; i++) {
+            const state = getCalendarState();
+            if (
+                state.year === earliestActivityDate.getFullYear()
+                && state.month === earliestActivityDate.getMonth()
+            ) {
+                break;
+            }
+            clickCalendarNav('prev-month-btn');
+            await flushDebounce();
+        }
+
+        expect(getCalendarState()).toEqual({
+            year: earliestActivityDate.getFullYear(),
+            month: earliestActivityDate.getMonth()
+        });
+        expect(document.getElementById('prev-month-btn').disabled).toBe(true);
+    });
+
     it('uses current month as lower bound when user has no sessions', async () => {
         initCalendar();
         resetToCurrentMonth();
@@ -342,6 +385,39 @@ describe('Calendar module', () => {
             month: expectedMonth
         });
         expect(getTrackReadCallsByLabel('calendar.minimumBound')).toHaveLength(1);
+    });
+
+    it('retries minimum-bound resolution after permissive fallback cooldown', async () => {
+        const invalidPath = `users/${user.uid}/sesiones_entrenamiento/session-retry-invalid`;
+        __firestoreState.documents.set(invalidPath, {
+            fecha: null,
+            ejercicios: [{ tipoEjercicio: 'strength' }]
+        });
+
+        initCalendar();
+        resetToCurrentMonth();
+        await flushDebounce();
+
+        const initialState = getCalendarState();
+        clickCalendarNav('prev-month-btn');
+        await flushDebounce();
+
+        const movedState = getCalendarState();
+        expect(movedState).not.toEqual(initialState);
+        expect(getTrackReadCallsByLabel('calendar.minimumBound')).toHaveLength(1);
+
+        __firestoreState.documents.set(invalidPath, {
+            fecha: Timestamp.fromDate(new Date(initialState.year, initialState.month, 5)),
+            ejercicios: [{ tipoEjercicio: 'strength' }]
+        });
+
+        jest.advanceTimersByTime(MINIMUM_BOUND_RETRY_MS + 1);
+        updateCalendarView();
+        await flushDebounce();
+
+        expect(getCalendarState()).toEqual(initialState);
+        expect(document.getElementById('prev-month-btn').disabled).toBe(true);
+        expect(getTrackReadCallsByLabel('calendar.minimumBound')).toHaveLength(2);
     });
 
     it('does not navigate beyond current month when pressing next', async () => {

--- a/tests/unit/calendar.test.js
+++ b/tests/unit/calendar.test.js
@@ -257,26 +257,56 @@ describe('Calendar module', () => {
         expect(mockTrackRead).toHaveBeenCalledTimes(1);
     });
 
-    it('navigates months and clamps at minimum calendar year', async () => {
+    it('navigates months and clamps at earliest activity month', async () => {
+        const today = new Date();
+        const earliestActivityDate = new Date(today.getFullYear(), today.getMonth(), 10);
+        earliestActivityDate.setMonth(earliestActivityDate.getMonth() - 2);
+
+        seedSession({
+            userId: user.uid,
+            id: 'session-earliest-1',
+            date: earliestActivityDate,
+            tipos: ['strength']
+        });
+
         initCalendar();
         resetToCurrentMonth();
         await flushDebounce();
 
         for (let i = 0; i < 60; i++) {
             const state = getCalendarState();
-            if (state.year === MIN_CALENDAR_YEAR && state.month === 0) break;
+            if (
+                state.year === earliestActivityDate.getFullYear()
+                && state.month === earliestActivityDate.getMonth()
+            ) {
+                break;
+            }
             clickCalendarNav('prev-month-btn');
             await flushDebounce();
         }
 
         const minimumState = getCalendarState();
-        expect(minimumState.year).toBe(MIN_CALENDAR_YEAR);
-        expect(minimumState.month).toBe(0);
+        expect(minimumState.year).toBe(earliestActivityDate.getFullYear());
+        expect(minimumState.month).toBe(earliestActivityDate.getMonth());
         expect(document.getElementById('prev-month-btn').disabled).toBe(true);
 
         clickCalendarNav('prev-month-btn');
         await flushDebounce();
         expect(getCalendarState()).toEqual(minimumState);
+    });
+
+    it('uses current month as lower bound when user has no sessions', async () => {
+        initCalendar();
+        resetToCurrentMonth();
+        await flushDebounce();
+
+        const stateBefore = getCalendarState();
+        expect(document.getElementById('prev-month-btn').disabled).toBe(true);
+
+        clickCalendarNav('prev-month-btn');
+        await flushDebounce();
+
+        expect(getCalendarState()).toEqual(stateBefore);
     });
 
     it('does not navigate beyond current month when pressing next', async () => {

--- a/tests/unit/calendar.test.js
+++ b/tests/unit/calendar.test.js
@@ -123,6 +123,10 @@ function clickCalendarNav(id) {
     calendarClickHandler({ target: { id } });
 }
 
+function getTrackReadCallsByLabel(label) {
+    return mockTrackRead.mock.calls.filter(([, operation]) => operation === label);
+}
+
 describe('Calendar module', () => {
     const user = { uid: 'calendar-user-1' };
 
@@ -232,7 +236,8 @@ describe('Calendar module', () => {
         expect(cell.classList.contains('level-3')).toBe(true);
         expect(cell.title).not.toContain(`${dateString}:`);
         expect(mockDeserializeActivityMap).toHaveBeenCalled();
-        expect(mockTrackRead).not.toHaveBeenCalled();
+        expect(getTrackReadCallsByLabel('calendar.monthlyActivity')).toHaveLength(0);
+        expect(getTrackReadCallsByLabel('calendar.minimumBound')).toHaveLength(1);
     });
 
     it('debounces repeated updateCalendarView calls', async () => {
@@ -254,7 +259,8 @@ describe('Calendar module', () => {
         expect(mockTrackRead).not.toHaveBeenCalled();
 
         await flushDebounce();
-        expect(mockTrackRead).toHaveBeenCalledTimes(1);
+        expect(getTrackReadCallsByLabel('calendar.monthlyActivity')).toHaveLength(1);
+        expect(getTrackReadCallsByLabel('calendar.minimumBound')).toHaveLength(1);
     });
 
     it('navigates months and clamps at earliest activity month', async () => {
@@ -307,6 +313,35 @@ describe('Calendar module', () => {
         await flushDebounce();
 
         expect(getCalendarState()).toEqual(stateBefore);
+    });
+
+    it('keeps backward navigation permissive when earliest activity payload is invalid', async () => {
+        __firestoreState.documents.set(
+            `users/${user.uid}/sesiones_entrenamiento/session-invalid-fecha`,
+            {
+                fecha: null,
+                ejercicios: [{ tipoEjercicio: 'strength' }]
+            }
+        );
+
+        initCalendar();
+        resetToCurrentMonth();
+        await flushDebounce();
+
+        const before = getCalendarState();
+        expect(document.getElementById('prev-month-btn').disabled).toBe(false);
+        expect(mockLoggerWarn).toHaveBeenCalledWith('Could not resolve earliest activity month due to invalid date payload.');
+
+        clickCalendarNav('prev-month-btn');
+        await flushDebounce();
+
+        const expectedMonth = before.month === 0 ? 11 : before.month - 1;
+        const expectedYear = before.month === 0 ? before.year - 1 : before.year;
+        expect(getCalendarState()).toEqual({
+            year: expectedYear,
+            month: expectedMonth
+        });
+        expect(getTrackReadCallsByLabel('calendar.minimumBound')).toHaveLength(1);
     });
 
     it('does not navigate beyond current month when pressing next', async () => {


### PR DESCRIPTION
## Summary
- replace fixed calendar lower bound with a per-user earliest-activity month
- keep current month as default and preserve the no-future-month navigation guard
- disable previous-month navigation only when the calendar is at the resolved earliest activity month
- fall back to current month when the user has no sessions
- keep backward navigation permissive for the current session if earliest-month lookup fails

## Tests
- `npm test -- tests/unit/calendar.test.js --runInBand`

Closes #73.