### PR TITLE
fix: preserve long Progress history beyond seven days [patch]

### DIFF
--- a/docs/progress-history-correctness-baseline.md
+++ b/docs/progress-history-correctness-baseline.md
@@ -36,9 +36,9 @@ node --experimental-vm-modules node_modules\\jest\\bin\\jest.js tests\\unit\\exe
 
 These passing tests do not cover long-history retention after login, restart, or offline Progress loading. Existing source telemetry labels the narrow integrity query as `exerciseCache.verifyIntegrity` and the bounded rebuild as `exerciseCache.buildFromHistory`; the Progress fallback is labeled `progress.sessionHistoryFallback` with a 300-session limit.
 
-## Pre-existing validation failures
+## Pre-existing validation failure and approved scope exception
 
-The full integration/app gates were run after the baseline and implementation checkpoint. The same unrelated failure occurred in both runs:
+The full integration/app gates were run before the CI repair. The same unrelated failure occurred locally and in CI:
 
 ```text
 tests/integration/app-offline-recovery.test.js:212
@@ -46,4 +46,21 @@ Expected: 2026-04-22T08:00:00.000Z
 Received: current wall-clock timestamp
 ```
 
-The failure is in the weekly-target timestamp fixture; `js/app.js` is unchanged by this task. The remaining integration result was 6 suites passed, 44 tests passed, 1 test failed. `app-offline-retry.test.js`, the app user journey, auth/navigation, language, and Firebase integration suites passed. Repository-wide `format:check` also reports 57 pre-existing files, while `lint:ratchet`, the focused suites, and the unit suite remain green.
+The queued payload retained the fixed weekly-rule timestamp, but `refreshDailyHub()` finalized past weekly outcomes with the wall clock and overwrote the preference document's `updatedAt` during replay. The approved scope exception was the smallest causal repair: pass the existing `getCurrentDateForWeeklyRules()` clock only to `finalizePastWeeklyOutcomes()`. Daily Hub's ordinary month-count clock remains unchanged; no schema, stored data, read bounds, or product scope changed.
+
+## Regression evidence after the repair
+
+The offline replay assertion now passes and proves that the persisted preference timestamp remains identical to the queued timestamp. Clean-install validation on July 21, 2026 produced:
+
+```text
+npm ci                                      passed
+npm run lint:ratchet                        passed
+npm run test:no-skips                       passed
+npm run test:unit                           35 suites, 644 tests passed
+npm run test:integration                    7 suites, 45 tests passed
+npm run test:coverage:gate                  42 suites, 689 tests passed; 72.63% statements; gate passed
+npm run test:app                            5 suites, 5 tests passed
+npm run test:app:offline                    2 suites, 2 tests passed
+```
+
+Repository-wide `format:check` remains a pre-existing baseline failure across 57 files. `npm audit --audit-level=high` remains a pre-existing dependency-tree failure with six high-severity advisories; neither gate was weakened or changed for this task.

--- a/docs/progress-history-correctness-baseline.md
+++ b/docs/progress-history-correctness-baseline.md
@@ -1,0 +1,49 @@
+# Progress History Correctness Baseline
+
+Captured July 21, 2026 on planning commit `d4339dd7388d66b8439971ec847401fd262fd8be`, branch `codex/gym-progress-history-correctness-v1`.
+
+## Reproduction
+
+The deterministic harness seeded three `Bench Press` sessions at 14, 30, and 365 days old, plus ten recent `Squat` sessions. Before cleanup, the exercise cache contained 3 Bench Press records and 10 Squat records. Running the login-time `ExerciseCacheManager.cleanOldEntries()` removed the Bench Press entry because `maxCacheAge` is seven days, while retaining the six Squat records still inside the window. A new cache manager then returned zero Bench Press records, reproducing the offline/restart loss.
+
+Observed result:
+
+```json
+{
+  "before": { "benchSessions": 3, "squatSessions": 10 },
+  "after": { "benchPresent": false, "squatSessions": 6 },
+  "offlineRestart": { "benchSessions": 0 },
+  "maxCacheAgeDays": 7
+}
+```
+
+The online login path currently performs a narrow `limit(10)` integrity query and only rebuilds when one of those recent sessions references a missing exercise. With ten newer sessions for another exercise, the old Bench Press history is outside that check and is not rebuilt. The Progress selector also requires at least three cached records per exercise, so the truncated entry is not selectable.
+
+## Baseline validation
+
+Focused suites passed before implementation changes:
+
+```text
+Test Suites: 5 passed, 5 total
+Tests:       75 passed, 75 total
+```
+
+Command:
+
+```text
+node --experimental-vm-modules node_modules\\jest\\bin\\jest.js tests\\unit\\exercise-cache.test.js tests\\unit\\progress-flow.test.js tests\\unit\\history-manager.test.js tests\\unit\\session-manager.test.js tests\\unit\\quick-log.test.js --runInBand
+```
+
+These passing tests do not cover long-history retention after login, restart, or offline Progress loading. Existing source telemetry labels the narrow integrity query as `exerciseCache.verifyIntegrity` and the bounded rebuild as `exerciseCache.buildFromHistory`; the Progress fallback is labeled `progress.sessionHistoryFallback` with a 300-session limit.
+
+## Pre-existing validation failures
+
+The full integration/app gates were run after the baseline and implementation checkpoint. The same unrelated failure occurred in both runs:
+
+```text
+tests/integration/app-offline-recovery.test.js:212
+Expected: 2026-04-22T08:00:00.000Z
+Received: current wall-clock timestamp
+```
+
+The failure is in the weekly-target timestamp fixture; `js/app.js` is unchanged by this task. The remaining integration result was 6 suites passed, 44 tests passed, 1 test failed. `app-offline-retry.test.js`, the app user journey, auth/navigation, language, and Firebase integration suites passed. Repository-wide `format:check` also reports 57 pre-existing files, while `lint:ratchet`, the focused suites, and the unit suite remain green.

--- a/js/app.js
+++ b/js/app.js
@@ -956,7 +956,7 @@ async function refreshDailyHub(user, options = {}) {
                 'Skipping weekly outcome freezing because Daily Hub weekly-window query was truncated; avoiding persistence of incomplete historical outcomes.'
             );
         } else {
-            await finalizePastWeeklyOutcomes(user, sessions, now);
+            await finalizePastWeeklyOutcomes(user, sessions, getCurrentDateForWeeklyRules());
         }
     }
     const state = computeDailyHubState({

--- a/js/exercise-cache.js
+++ b/js/exercise-cache.js
@@ -1,5 +1,6 @@
 // Exercise Cache Manager
-// Manages local caching of exercise history for better UX and reduced Firebase calls
+// Manages short-lived exercise suggestion data for better UX and reduced Firebase calls.
+// Progress analytics use the bounded session-history cache in progress.js.
 
 import { logger } from './utils/logger.js';
 import { firebaseUsageTracker } from './utils/firebase-usage-tracker.js';
@@ -21,7 +22,7 @@ export class ExerciseCacheManager {
         this.integrityCheckKey = 'gym-tracker-exercise-cache-integrity';
         this.integrityCheckIntervalMs = 6 * 60 * 60 * 1000;
         this.maxCacheAge = 7 * 24 * 60 * 60 * 1000; // 7 días en milisegundos
-        // NOTE: Exercise history is unlimited by count but subject to 7-day age cleanup via cleanOldEntries()
+        // NOTE: This cache is suggestion data and is intentionally age-limited.
     }
 
     /**
@@ -167,7 +168,7 @@ export class ExerciseCacheManager {
         // Añadir al principio del array (más reciente primero)
         cache[cacheKey].history.unshift(historyEntry);
 
-        // No limitar el historial - necesitamos todos los datos para gráficos de progreso. El historial se limpará automáticamente por edad usando cleanOldEntries()
+        // Keep recent suggestion history until cleanOldEntries() applies the age bound.
 
         this.saveFullCache(cache);
     }
@@ -434,7 +435,7 @@ export class ExerciseCacheManager {
     }
 
     /**
-     * Limpia entradas antiguas del cache
+     * Limpia entradas antiguas del cache de sugerencias
      */
     cleanOldEntries() {
         const cache = this.getFullCache();

--- a/js/modules/session-manager.js
+++ b/js/modules/session-manager.js
@@ -128,6 +128,7 @@ offlineManager.registerOperationHandler('session.save', async (payload) => {
     const userSessionsCollectionRef = collection(db, 'users', payload.userId, 'sesiones_entrenamiento');
     await addDoc(userSessionsCollectionRef, hydratedSession);
     firebaseUsageTracker.trackWrite(1, 'session.save.replayed');
+    invalidateProgressCache();
 });
 
 offlineManager.registerOperationHandler('quicklog.save', async (payload) => {
@@ -139,6 +140,7 @@ offlineManager.registerOperationHandler('quicklog.save', async (payload) => {
     const userSessionsCollectionRef = collection(db, 'users', payload.userId, 'sesiones_entrenamiento');
     await addDoc(userSessionsCollectionRef, hydratedSession);
     firebaseUsageTracker.trackWrite(1, 'quicklog.save.replayed');
+    invalidateProgressCache();
 });
 
 /**
@@ -479,6 +481,7 @@ export async function saveQuickLogEntry(quickLogInput = {}, onSuccess, options =
             }
         );
 
+        invalidateProgressCache();
         invalidatePostSaveCaches(user.uid);
         toast.success(t('quicklog.saved_success'));
 

--- a/js/progress.js
+++ b/js/progress.js
@@ -126,32 +126,6 @@ function buildExerciseDescriptor(
     return parseExerciseSelectionValue(buildExerciseSelectionValue(exerciseName, mode, normalizedLoadType));
 }
 
-function inferExecutionModeFromCacheEntry(entry = {}, cacheKey = '') {
-    if (entry.executionMode) {
-        return normalizeExecutionMode(entry.executionMode);
-    }
-
-    const modeMatch = cacheKey.match(/__(one_hand|two_hand|machine|pulley|other)(?:__(external|bodyweight))?$/);
-    if (modeMatch && modeMatch[1]) {
-        return normalizeExecutionMode(modeMatch[1]);
-    }
-
-    return DEFAULT_EXECUTION_MODE;
-}
-
-function inferLoadTypeFromCacheEntry(entry = {}, cacheKey = '') {
-    if (entry.loadType) {
-        return normalizeLoadType(entry.loadType);
-    }
-
-    const loadTypeMatch = cacheKey.match(/__(external|bodyweight)$/);
-    if (loadTypeMatch && loadTypeMatch[1]) {
-        return normalizeLoadType(loadTypeMatch[1]);
-    }
-
-    return DEFAULT_LOAD_TYPE;
-}
-
 function resolveSetWeightForMetrics(set = {}, loadType = DEFAULT_LOAD_TYPE, fallbackBodyweight = null) {
     const normalizedLoadType = normalizeLoadType(loadType);
 
@@ -179,6 +153,10 @@ function isProgressCacheValid() {
 
     const cacheAge = Date.now() - progressTabCache.lastCacheTime;
     return cacheAge < progressTabCache.cacheValidityTime;
+}
+
+function isProgressOnline() {
+    return typeof navigator === 'undefined' || navigator.onLine !== false;
 }
 
 export function invalidateProgressCache() {
@@ -300,57 +278,8 @@ export async function loadExerciseList() {
     showProgressLoading();
 
     try {
-        const { exerciseCache } = await import('./exercise-cache.js');
-        let fullCache = exerciseCache.exportCache();
-
-        if (Object.keys(fullCache).length === 0) {
-            const { getCurrentUser } = await import('./auth.js');
-            const { db } = await import('./firebase-config.js');
-            const user = getCurrentUser();
-
-            if (user && db) {
-                await exerciseCache.validateAndRebuildCache(user.uid, db);
-                fullCache = exerciseCache.exportCache();
-            }
-        }
-
-        const exercisesWithCount = [];
-        Object.keys(fullCache).forEach((exerciseKey) => {
-            const exercise = fullCache[exerciseKey];
-            if (!exercise.originalName || !exercise.history || exercise.history.length < 3) {
-                return;
-            }
-
-            const executionMode = inferExecutionModeFromCacheEntry(exercise, exerciseKey);
-            const loadType = inferLoadTypeFromCacheEntry(exercise, exerciseKey);
-            const descriptor = buildExerciseDescriptor(exercise.originalName, executionMode, loadType);
-            exercisesWithCount.push({
-                ...descriptor,
-                sessionCount: exercise.history.length
-            });
-        });
-
-        exercisesWithCount.sort((a, b) => {
-            if (b.sessionCount !== a.sessionCount) {
-                return b.sessionCount - a.sessionCount;
-            }
-            return a.label.localeCompare(b.label);
-        });
-
-        const sortedExercises = exercisesWithCount.map((exercise) => ({
-            value: exercise.value,
-            label: exercise.label,
-            name: exercise.name,
-            executionMode: exercise.executionMode,
-            loadType: exercise.loadType
-        }));
-
-        if (sortedExercises.length === 0) {
-            const fallbackData = await loadExercisesFromSessions();
-            populateExerciseSelector(fallbackData.names, false, fallbackData.withCounts);
-        } else {
-            populateExerciseSelector(sortedExercises, false, exercisesWithCount);
-        }
+        const sessionHistory = await loadExercisesFromSessionHistory();
+        populateExerciseSelector(sessionHistory.names, false, sessionHistory.withCounts);
     } catch (error) {
         logger.error('Error loading exercise list:', error);
         progressElements.exerciseSelect.innerHTML = `<option value="">${t('progress.loading_error')}</option>`;
@@ -419,81 +348,7 @@ async function getExerciseData(exerciseSelection, period) {
             return exerciseDataCache.get(cacheKey);
         }
 
-        const { exerciseCache } = await import('./exercise-cache.js');
-        const fullCache = exerciseCache.exportCache();
-
-        const normalizedSelectedName = normalizeExerciseName(exerciseSelection.name);
-        const selectedMode = normalizeExecutionMode(exerciseSelection.executionMode);
-        const selectedLoadType = normalizeLoadType(exerciseSelection.loadType);
-
-        const exerciseKey = Object.keys(fullCache).find((key) => {
-            const cacheEntry = fullCache[key];
-            const normalizedName = normalizeExerciseName(cacheEntry.originalName);
-            const cacheMode = inferExecutionModeFromCacheEntry(cacheEntry, key);
-            const cacheLoadType = inferLoadTypeFromCacheEntry(cacheEntry, key);
-            return (
-                normalizedName === normalizedSelectedName
-                && cacheMode === selectedMode
-                && cacheLoadType === selectedLoadType
-            );
-        });
-
-        if (!exerciseKey || !fullCache[exerciseKey].history) {
-            return await getExerciseDataFromSessions(exerciseSelection, period);
-        }
-
-        let exerciseHistory = fullCache[exerciseKey].history;
-
-        const now = new Date();
-        let startDate = new Date();
-        switch (period) {
-            case '3m':
-                startDate.setMonth(now.getMonth() - 3);
-                break;
-            case '6m':
-                startDate.setMonth(now.getMonth() - 6);
-                break;
-            case '1y':
-                startDate.setFullYear(now.getFullYear() - 1);
-                break;
-            case 'all':
-            default:
-                startDate = new Date('2020-01-01');
-                break;
-        }
-
-        exerciseHistory = exerciseHistory.filter((record) => {
-            const recordDate = record.date instanceof Date ? record.date : new Date(record.date);
-            return recordDate >= startDate;
-        });
-
-        const processedData = exerciseHistory.map((record) => {
-            const recordDate = record.date instanceof Date ? record.date : new Date(record.date);
-            let maxWeight = Number.NEGATIVE_INFINITY;
-            let totalVolume = 0;
-            let maxReps = 0;
-
-            if (record.sets && Array.isArray(record.sets)) {
-                record.sets.forEach((set) => {
-                    const weight = resolveSetWeightForMetrics(set, selectedLoadType);
-                    const reps = parseInt(set.reps || set.repeticiones || 0, 10);
-
-                    if (weight > maxWeight) maxWeight = weight;
-                    if (reps > maxReps) maxReps = reps;
-                    totalVolume += weight * reps;
-                });
-            }
-
-            return {
-                date: recordDate,
-                weight: maxWeight === Number.NEGATIVE_INFINITY ? 0 : maxWeight,
-                volume: totalVolume,
-                reps: maxReps,
-                sets: record.sets
-            };
-        });
-
-        processedData.sort((a, b) => a.date - b.date);
+        const processedData = await getExerciseDataFromSessionHistory(exerciseSelection, period);
         exerciseDataCache.set(cacheKey, processedData);
 
         return processedData;
@@ -510,9 +365,20 @@ async function loadSessionHistoryForProgress() {
 
     const cacheKey = `progress:sessions:${user.uid}`;
     const cachedEntry = await localFirstCache.getEntry(cacheKey);
+    const hasCachedSessions = Array.isArray(cachedEntry?.value);
+    const cachedSessions = hasCachedSessions
+        ? deserializeSessionsFromCache(cachedEntry.value).slice(0, MAX_PROGRESS_SESSIONS)
+        : [];
 
-    if (cachedEntry?.value && Array.isArray(cachedEntry.value) && localFirstCache.isFresh(cachedEntry, PROGRESS_SESSIONS_CACHE_TTL_MS)) {
-        return deserializeSessionsFromCache(cachedEntry.value);
+    if (hasCachedSessions && (
+        localFirstCache.isFresh(cachedEntry, PROGRESS_SESSIONS_CACHE_TTL_MS)
+        || !isProgressOnline()
+    )) {
+        return cachedSessions;
+    }
+
+    if (!isProgressOnline()) {
+        return cachedSessions;
     }
 
     const { db } = await import('./firebase-config.js');
@@ -526,7 +392,9 @@ async function loadSessionHistoryForProgress() {
         limit: MAX_PROGRESS_SESSIONS
     });
 
-    const sessions = querySnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+    const sessions = querySnapshot.docs
+        .map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
+        .slice(0, MAX_PROGRESS_SESSIONS);
 
     await localFirstCache.set(cacheKey, serializeSessionsForCache(sessions), {
         metadata: {
@@ -538,9 +406,9 @@ async function loadSessionHistoryForProgress() {
     return sessions;
 }
 
-async function getExerciseDataFromSessions(exerciseSelection, period) {
+async function getExerciseDataFromSessionHistory(exerciseSelection, period) {
     try {
-        logger.info(`Fallback: Loading ${exerciseSelection.label} data directly from sessions`);
+        logger.info(`Analytical history: Loading ${exerciseSelection.label} data from bounded sessions`);
         const sessions = await loadSessionHistoryForProgress();
 
         const exerciseData = [];
@@ -628,7 +496,7 @@ async function getExerciseDataFromSessions(exerciseSelection, period) {
 
         return filteredData;
     } catch (error) {
-        logger.error('Error in fallback exercise data loading:', error);
+        logger.error('Error in analytical exercise history loading:', error);
         return [];
     }
 }
@@ -910,7 +778,7 @@ export function resetProgressView() {
     }
 }
 
-async function loadExercisesFromSessions() {
+async function loadExercisesFromSessionHistory() {
     try {
         const sessions = await loadSessionHistoryForProgress();
 
@@ -921,7 +789,12 @@ async function loadExercisesFromSessions() {
             if (sessionData.ejercicios && Array.isArray(sessionData.ejercicios)) {
                 sessionData.ejercicios.forEach((ejercicio) => {
                     const exerciseName = ejercicio.nombreEjercicio || ejercicio.name || ejercicio.ejercicio;
-                    if (exerciseName && ejercicio.tipoEjercicio === 'strength') {
+                    if (
+                        exerciseName
+                        && ejercicio.tipoEjercicio === 'strength'
+                        && Array.isArray(ejercicio.sets)
+                        && ejercicio.sets.length > 0
+                    ) {
                         const executionMode = resolveExerciseExecutionMode(ejercicio);
                         const loadType = normalizeLoadType(resolveExerciseLoadType(ejercicio));
                         const descriptor = buildExerciseDescriptor(exerciseName, executionMode, loadType);
@@ -967,7 +840,7 @@ async function loadExercisesFromSessions() {
             withCounts: exercisesWithCount
         };
     } catch (error) {
-        logger.error('Error in fallback exercise loading:', error);
+        logger.error('Error in analytical exercise history selector loading:', error);
         return { names: [], withCounts: [] };
     }
 }

--- a/tests/unit/progress-flow.test.js
+++ b/tests/unit/progress-flow.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { MockTimestamp, __firestoreState, __resetMockFirebase } from '../mocks/firebase-state.js';
 
 const mockClearByPrefix = jest.fn(() => Promise.resolve());
 const mockGetEntry = jest.fn();
@@ -8,8 +9,6 @@ const mockTrackRead = jest.fn();
 const mockSerializeSessionsForCache = jest.fn((sessions) => sessions);
 const mockDeserializeSessionsFromCache = jest.fn((sessions) => sessions);
 const mockGetCurrentUser = jest.fn();
-const mockValidateAndRebuildCache = jest.fn();
-const mockExportCache = jest.fn();
 
 const progressElements = {
     exerciseSelect: null,
@@ -66,13 +65,6 @@ jest.unstable_mockModule('../../js/firebase-config.js', () => ({
     db: { __isMockDb: true }
 }));
 
-jest.unstable_mockModule('../../js/exercise-cache.js', () => ({
-    exerciseCache: {
-        exportCache: mockExportCache,
-        validateAndRebuildCache: mockValidateAndRebuildCache
-    }
-}));
-
 const progressModule = await import('../../js/progress.js');
 
 const {
@@ -88,7 +80,12 @@ function setupProgressDom() {
     document.body.innerHTML = `
         <select id="exercise-select"></select>
         <select id="metric-select"><option value="weight">weight</option><option value="reps">reps</option></select>
-        <select id="period-select"><option value="all">all</option></select>
+        <select id="period-select">
+            <option value="3m">3m</option>
+            <option value="6m">6m</option>
+            <option value="1y">1y</option>
+            <option value="all">all</option>
+        </select>
         <div id="progress-loading" class="hidden"></div>
         <div id="progress-chart-container" class="hidden"></div>
         <canvas id="progress-chart"></canvas>
@@ -115,17 +112,28 @@ function setupProgressDom() {
     progressElements.chart.getContext = jest.fn(() => ({}));
 }
 
-function buildHistory(weights) {
+function buildSessionHistory(weights, exerciseName = 'Bench Press') {
     return weights.map((weight, idx) => ({
-        date: new Date(`2026-03-0${idx + 1}T08:00:00.000Z`).toISOString(),
-        sets: [{ peso: weight, reps: 8 }]
+        id: `session-${idx + 1}`,
+        fecha: {
+            toDate: () => new Date(`2026-03-0${idx + 1}T08:00:00.000Z`)
+        },
+        ejercicios: [{
+            nombreEjercicio: exerciseName,
+            tipoEjercicio: 'strength',
+            modoEjecucion: 'two_hand',
+            tipoCarga: 'external',
+            sets: [{ peso: weight, reps: 8 }]
+        }]
     }));
 }
 
 describe('progress flow', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        __resetMockFirebase();
         setupProgressDom();
+        setProgressOnline(true);
         mockGetCurrentUser.mockReturnValue({ uid: 'user-progress-1' });
         mockIsFresh.mockReturnValue(true);
         mockGetEntry.mockResolvedValue(null);
@@ -134,16 +142,50 @@ describe('progress flow', () => {
         invalidateProgressCache();
     });
 
-    it('loads exercise list from cache manager and reuses in-memory cache', async () => {
-        mockExportCache.mockReturnValue({
-            bench_press: {
-                originalName: 'Bench Press',
-                history: buildHistory([60, 65, 70, 72])
-            },
-            squats: {
-                originalName: 'Squats',
-                history: buildHistory([80, 85, 90])
-            }
+    function buildFirestoreSession(id, date, exerciseName, weight, options = {}) {
+        const exercise = {
+            nombreEjercicio: exerciseName,
+            tipoEjercicio: 'strength',
+            modoEjecucion: options.executionMode || 'two_hand',
+            tipoCarga: options.loadType || 'external',
+            sets: [{
+                peso: weight,
+                reps: options.reps || 8,
+                ...(options.totalWeight === undefined ? {} : { pesoTotal: options.totalWeight })
+            }]
+        };
+
+        return {
+            id,
+            fecha: MockTimestamp.fromDate(date),
+            pesoUsuario: options.bodyweight || null,
+            ejercicios: [exercise]
+        };
+    }
+
+    function seedFirestoreSessions(sessions) {
+        sessions.forEach((session) => {
+            __firestoreState.documents.set(
+                `users/user-progress-1/sesiones_entrenamiento/${session.id}`,
+                session
+            );
+        });
+    }
+
+    function setProgressOnline(value) {
+        Object.defineProperty(navigator, 'onLine', {
+            configurable: true,
+            value
+        });
+    }
+
+    it('loads exercise list from bounded session history and reuses in-memory cache', async () => {
+        mockGetEntry.mockResolvedValue({
+            value: [
+                ...buildSessionHistory([60, 65, 70, 72], 'Bench Press'),
+                ...buildSessionHistory([80, 85, 90], 'Squats')
+            ],
+            updatedAt: Date.now()
         });
 
         await loadExerciseList();
@@ -152,22 +194,123 @@ describe('progress flow', () => {
         expect(optionLabels[0]).toContain('Selecciona');
         expect(optionLabels).toContain('Bench Press (4 sesiones)');
         expect(optionLabels).toContain('Squats (3 sesiones)');
-        expect(mockExportCache).toHaveBeenCalledTimes(1);
+        expect(mockGetEntry).toHaveBeenCalledTimes(1);
 
-        mockExportCache.mockReturnValue({});
+        mockGetEntry.mockResolvedValue(null);
         await loadExerciseList();
-        expect(mockExportCache).toHaveBeenCalledTimes(1);
+        expect(mockGetEntry).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps older exercises selectable after a reload/restart while offline', async () => {
+        resetProgressView();
+        setProgressOnline(false);
+        mockIsFresh.mockReturnValue(false);
+        mockGetEntry.mockResolvedValue({
+            value: buildSessionHistory([60, 65, 70]),
+            updatedAt: Date.now() - (30 * 24 * 60 * 60 * 1000)
+        });
+
+        await loadExerciseList();
+
+        const optionLabels = Array.from(progressElements.exerciseSelect.options).map((opt) => opt.textContent);
+        expect(optionLabels).toContain('Bench Press (3 sesiones)');
+        expect(mockTrackRead).not.toHaveBeenCalled();
+    });
+
+    it('uses one bounded online session query for long history and preserves range counts', async () => {
+        setProgressOnline(true);
+        mockIsFresh.mockReturnValue(false);
+
+        const now = new Date();
+        const daysAgo = (days) => new Date(now.getTime() - (days * 24 * 60 * 60 * 1000));
+        const benchSessions = [500, 430, 330, 250, 190, 170, 130, 100, 80, 50, 20]
+            .map((days, index) => buildFirestoreSession(
+                `bench-${index + 1}`,
+                daysAgo(days),
+                'Bench Press',
+                60 + index
+            ));
+        const otherSessions = Array.from({ length: 10 }, (_, index) => buildFirestoreSession(
+            `squat-${index + 1}`,
+            daysAgo(index + 1),
+            'Squat',
+            100 + index
+        ));
+        const sessions = [...benchSessions, ...otherSessions];
+        seedFirestoreSessions(sessions);
+        mockGetEntry.mockResolvedValue(null);
+
+        await loadExerciseList();
+
+        const benchOption = Array.from(progressElements.exerciseSelect.options)
+            .find((option) => option.textContent.startsWith('Bench Press'));
+        expect(benchOption).toBeDefined();
+        expect(benchOption.textContent).toBe('Bench Press (11 sesiones)');
+        expect(mockTrackRead).toHaveBeenCalledWith(21, 'progress.sessionHistoryFallback', {
+            limit: 300
+        });
+
+        mockGetEntry.mockResolvedValue({ value: sessions, updatedAt: Date.now() });
+        progressElements.exerciseSelect.value = benchOption.value;
+        progressElements.metricSelect.value = 'weight';
+
+        for (const [period, expectedCount] of [['3m', 3], ['6m', 6], ['1y', 9], ['all', 11]]) {
+            progressElements.periodSelect.value = period;
+            await updateChart();
+            expect(progressElements.sessionCount.textContent).toBe(String(expectedCount));
+        }
+    });
+
+    it('keeps execution variants and body-weight totals distinct in analytical history', async () => {
+        setProgressOnline(false);
+        mockIsFresh.mockReturnValue(false);
+        const now = new Date();
+        const sessions = [
+            ...[1, 2, 3].map((days, index) => buildFirestoreSession(
+                `one-hand-${index + 1}`,
+                new Date(now.getTime() - (days * 24 * 60 * 60 * 1000)),
+                'Bench Press',
+                60 + index,
+                { executionMode: 'one_hand' }
+            )),
+            ...[4, 5, 6].map((days, index) => buildFirestoreSession(
+                `bodyweight-${index + 1}`,
+                new Date(now.getTime() - (days * 24 * 60 * 60 * 1000)),
+                'Bench Press',
+                10 + index,
+                {
+                    executionMode: 'machine',
+                    loadType: 'bodyweight',
+                    bodyweight: 80,
+                    totalWeight: 90 + index
+                }
+            ))
+        ];
+        mockGetEntry.mockResolvedValue({ value: sessions, updatedAt: Date.now() });
+
+        await loadExerciseList();
+
+        const options = Array.from(progressElements.exerciseSelect.options);
+        const oneHandOption = options.find((option) => option.value.includes('mode=one_hand'));
+        const bodyweightOption = options.find((option) => option.value.includes('mode=machine') && option.value.includes('load=bodyweight'));
+        expect(oneHandOption).toBeDefined();
+        expect(bodyweightOption).toBeDefined();
+
+        progressElements.exerciseSelect.value = bodyweightOption.value;
+        progressElements.periodSelect.value = 'all';
+        await updateChart();
+
+        expect(progressElements.sessionCount.textContent).toBe('3');
+        expect(progressElements.bestRecord.textContent).toBe('92.0 kg');
     });
 
     it('updates chart and stats when enough data points exist', async () => {
-        mockExportCache.mockReturnValue({
-            bench_press: {
-                originalName: 'Bench Press',
-                history: buildHistory([60, 65, 70, 72])
-            }
+        mockGetEntry.mockResolvedValue({
+            value: buildSessionHistory([60, 65, 70, 72]),
+            updatedAt: Date.now()
         });
 
-        progressElements.exerciseSelect.innerHTML = '<option value="Bench Press" selected>Bench Press</option>';
+        progressElements.exerciseSelect.innerHTML = '<option value="Bench%20Press::mode=two_hand::load=external" selected>Bench Press</option>';
         progressElements.metricSelect.value = 'weight';
         progressElements.periodSelect.value = 'all';
 
@@ -184,14 +327,12 @@ describe('progress flow', () => {
     });
 
     it('shows no-data state when fewer than three data points exist', async () => {
-        mockExportCache.mockReturnValue({
-            bench_press: {
-                originalName: 'Bench Press',
-                history: buildHistory([60, 65])
-            }
+        mockGetEntry.mockResolvedValue({
+            value: buildSessionHistory([60, 65]),
+            updatedAt: Date.now()
         });
 
-        progressElements.exerciseSelect.innerHTML = '<option value="Bench Press" selected>Bench Press</option>';
+        progressElements.exerciseSelect.innerHTML = '<option value="Bench%20Press::mode=two_hand::load=external" selected>Bench Press</option>';
         progressElements.metricSelect.value = 'weight';
         progressElements.periodSelect.value = 'all';
 
@@ -225,14 +366,12 @@ describe('progress flow', () => {
     });
 
     it('resets progress view and restores default selector placeholder', async () => {
-        mockExportCache.mockReturnValue({
-            bench_press: {
-                originalName: 'Bench Press',
-                history: buildHistory([60, 65, 70])
-            }
+        mockGetEntry.mockResolvedValue({
+            value: buildSessionHistory([60, 65, 70]),
+            updatedAt: Date.now()
         });
 
-        progressElements.exerciseSelect.innerHTML = '<option value="Bench Press" selected>Bench Press</option>';
+        progressElements.exerciseSelect.innerHTML = '<option value="Bench%20Press::mode=two_hand::load=external" selected>Bench Press</option>';
         progressElements.metricSelect.value = 'weight';
         progressElements.periodSelect.value = 'all';
         await updateChart();

--- a/tests/unit/session-manager.test.js
+++ b/tests/unit/session-manager.test.js
@@ -444,6 +444,7 @@ describe('Session Manager', () => {
             })
         );
         expect(mockTrackWrite).toHaveBeenCalledWith(1, 'quicklog.save');
+        expect(mockInvalidateProgressCache).toHaveBeenCalled();
         expect(mockClearByPrefix).toHaveBeenCalledWith(`history:${user.uid}:`);
         expect(mockClearByPrefix).toHaveBeenCalledWith(`calendar:${user.uid}:`);
         expect(onSuccess).toHaveBeenCalled();


### PR DESCRIPTION
## What changed

- Make the bounded local-first session history (`progress:sessions:{uid}`, max 300 sessions) the canonical source for Progress exercise selection and charts.
- Keep the seven-day exercise cache scoped to short-lived workout suggestions.
- Allow persisted session history to serve Progress while offline, including stale cache entries after reload/restart.
- Invalidate Progress after online session saves, Quick Log saves, and replayed queued operations.
- Add regression coverage for long history, 3m/6m/1y/all ranges, restart/offline recovery, bounded read telemetry, execution variants, and body-weight totals.

## Root cause and impact

Progress used an exercise cache that is cleaned at seven days, while its fallback session query was only reached when the cache had no usable exercises. Older exercises could therefore disappear from the selector and charts after login or offline restart, even though the saved sessions still existed.

The same PR also contains the smallest causally justified repair for a pre-existing CI gate failure: weekly preference replay retained the queued timestamp, but Daily Hub outcome finalization overwrote it with the wall clock. The existing weekly-rule clock is now passed only to that finalization path; Daily Hub month counts and stored data remain unchanged.

## Validation

- `npm ci` — passed.
- `npm run lint:ratchet` — passed.
- `npm run test:no-skips` — passed.
- All unit tests — 35 suites, 644 tests passed.
- All integration tests — 7 suites, 45 tests passed.
- `npm run test:coverage:gate` — 42 suites, 689 tests passed at 72.63% statements.
- `npm run test:app` and `npm run test:app:offline` — passed.
- Real-browser desktop/mobile validation with seeded long history — 3m/6m/1y/all counts 3/4/5/6; labeled controls, focus order, no mobile horizontal overflow, and no console/page/request errors.
- Repository-wide `format:check` remains a documented non-blocking baseline warning across 57 files; `npm audit --audit-level=high` reports six pre-existing high-severity dependency advisories. Neither gate was weakened.
- GitHub Actions Run Tests `29858993788` passed on head `67b07af2e2501875b444a1a36500ae364bf4b666`; all PR checks are green.
- Deep final review found no blocking scope, data, security, accessibility, or regression issues.

The Copilot reviewer returned only a quota-unavailable notice and no actionable review feedback.