### PR TITLE
fix: add fixed portfolio cache delivery target

### DIFF
--- a/.github/workflows/cloudflare-cache.yml
+++ b/.github/workflows/cloudflare-cache.yml
@@ -1,55 +1,97 @@
 name: Purge and Verify Canonical Cache
 
 on:
-  workflow_dispatch:
-    inputs:
-      revision_sha:
-        description: 'Deployed main commit to purge and verify'
-        required: true
-        type: string
-  workflow_run:
-    workflows: ['Create Release']
-    types: [completed]
-    branches: [main]
+    workflow_dispatch:
+        inputs:
+            target:
+                description: Fixed application target to reconcile
+                required: true
+                type: choice
+                options:
+                    - gym
+                    - portfolio
+                default: gym
+            revision_sha:
+                description: Deployed commit SHA of the selected target repository
+                required: true
+                type: string
+            expected_revision:
+                description: Expected immutable application revision from the selected target manifest
+                required: true
+                type: string
+    workflow_run:
+        workflows: ['Create Release']
+        types: [completed]
+        branches: [main]
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  purge-and-verify:
-    name: Purge Cloudflare and verify release
-    if: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment:
-      name: production
-    steps:
-      - name: Checkout deployed Pages revision
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.revision_sha || github.event.workflow_run.head_sha }}
+    purge-and-verify:
+        name: Purge Cloudflare and verify release
+        if: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (inputs.target == 'gym' || inputs.target == 'portfolio')) || (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success') }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        environment:
+            name: production
+        steps:
+            - name: Checkout Gym cache-control surface
+              uses: actions/checkout@v6
+              with:
+                  repository: metalfurius/gym
+                  ref: main
+                  path: control-plane
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
+            - name: Checkout deployed Gym revision
+              if: ${{ github.event_name == 'workflow_run' || inputs.target == 'gym' }}
+              uses: actions/checkout@v6
+              with:
+                  repository: metalfurius/gym
+                  ref: ${{ github.event_name == 'workflow_dispatch' && inputs.revision_sha || github.event.workflow_run.head_sha }}
+                  path: target-gym
 
-      - name: Validate scoped cache token, policy, and purge canonical URLs
-        run: npm run cloudflare:cache:purge
-        env:
-          CLOUDFLARE_CACHE_API_TOKEN: ${{ secrets.CLOUDFLARE_CACHE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+            - name: Checkout deployed portfolio revision
+              if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'portfolio' }}
+              uses: actions/checkout@v6
+              with:
+                  repository: metalfurius/metalfurius.github.io
+                  ref: ${{ inputs.revision_sha }}
+                  path: target-portfolio
 
-      - name: Verify no-query production release coherence
-        run: npm run production:release:smoke
-        env:
-          GYM_PUBLIC_BASE_URL: https://codeoverdose.es/gym/
-          PRODUCTION_SMOKE_EVIDENCE_PATH: production-release-smoke.json
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: '22'
+                  cache: npm
+                  cache-dependency-path: control-plane/package-lock.json
 
-      - name: Upload production evidence
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: gym-production-release-smoke-${{ github.event_name == 'workflow_dispatch' && inputs.revision_sha || github.event.workflow_run.head_sha }}
-          path: production-release-smoke.json
-          if-no-files-found: ignore
+            - name: Install locked control-plane toolchain
+              working-directory: control-plane
+              run: npm ci
+
+            - name: Validate scoped cache token, policy, and purge canonical URLs
+              working-directory: control-plane
+              run: npm run cloudflare:cache:purge
+              env:
+                  CLOUDFLARE_CACHE_API_TOKEN: ${{ secrets.CLOUDFLARE_CACHE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_CACHE_TARGET: ${{ inputs.target || 'gym' }}
+                  CLOUDFLARE_EXPECTED_REVISION: ${{ inputs.expected_revision || '' }}
+
+            - name: Verify no-query production release coherence
+              working-directory: control-plane
+              run: npm run production:release:smoke
+              env:
+                  PRODUCTION_SMOKE_TARGET: ${{ inputs.target || 'gym' }}
+                  PRODUCTION_SMOKE_EVIDENCE_PATH: production-release-smoke.json
+                  PRODUCTION_SMOKE_RETRY_COUNT: '4'
+                  PRODUCTION_SMOKE_RETRY_DELAY_MS: '5000'
+
+            - name: Upload production evidence
+              if: always()
+              uses: actions/upload-artifact@v6
+              with:
+                  name: canonical-cache-smoke-${{ inputs.target || 'gym' }}-${{ inputs.revision_sha || github.event.workflow_run.head_sha }}
+                  path: control-plane/production-release-smoke.json
+                  if-no-files-found: ignore

--- a/scripts/cloudflare-cache-control.mjs
+++ b/scripts/cloudflare-cache-control.mjs
@@ -10,25 +10,72 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const API_BASE = 'https://api.cloudflare.com/client/v4';
 const TOKEN_ENV = 'CLOUDFLARE_CACHE_API_TOKEN';
 const ACCOUNT_ID_ENV = 'CLOUDFLARE_ACCOUNT_ID';
+const TARGET_ENV = 'CLOUDFLARE_CACHE_TARGET';
+const EXPECTED_REVISION_ENV = 'CLOUDFLARE_EXPECTED_REVISION';
 const ZONE_NAME = 'codeoverdose.es';
-const PUBLIC_BASE_URL = 'https://codeoverdose.es/gym/';
 const CACHE_RULE_PHASE = 'http_request_cache_settings';
-const CACHE_RULE_REF = 'gym-pwa-fixed-cache-policy-v1';
 const PURGE_BATCH_SIZE = 25;
 const CLOUDFLARE_ID_PATTERN = /^[a-f0-9]{32}$/i;
-const TARGET_CACHE_RULE = {
-    ref: CACHE_RULE_REF,
-    description: 'Bypass Cloudflare caching for Gym release delivery',
-    expression: '(http.host eq "codeoverdose.es" and starts_with(http.request.uri.path, "/gym/"))',
-    action: 'set_cache_settings',
-    action_parameters: {
-        cache: false,
+const PORTFOLIO_MEDIA_PATHS = [
+    'assets/1.png',
+    'assets/2.png',
+    'assets/2048.webp',
+    'assets/cc.webp',
+    'assets/gym-icon.png',
+    'assets/luckbound_concept.jpg',
+    'assets/logo.png',
+];
+
+const TARGET_CONFIGS = {
+    gym: {
+        targetDirectory: 'target-gym',
+        baseUrl: 'https://codeoverdose.es/gym/',
+        metadataFile: 'release.json',
+        fixedPaths: ['', 'index.html', 'manifest.json', 'release.json', 'sw.js'],
+        cacheRule: {
+            ref: 'gym-pwa-fixed-cache-policy-v1',
+            description: 'Bypass Cloudflare caching for Gym release delivery',
+            expression: '(http.host eq "codeoverdose.es" and starts_with(http.request.uri.path, "/gym/"))',
+            action: 'set_cache_settings',
+            action_parameters: { cache: false },
+            enabled: true,
+        },
     },
-    enabled: true,
+    portfolio: {
+        targetDirectory: 'target-portfolio',
+        baseUrl: 'https://codeoverdose.es/',
+        metadataFile: 'site-revision.json',
+        fixedPaths: ['', 'index.html', 'site-revision.json', 'styles.css', 'script.js', ...PORTFOLIO_MEDIA_PATHS],
+        cacheRule: {
+            ref: 'portfolio-canonical-cache-policy-v1',
+            description: 'Bypass Cloudflare caching for CodeOverdose portfolio delivery',
+            expression:
+                '(http.host eq "codeoverdose.es" and (http.request.uri.path eq "/" or http.request.uri.path eq "/index.html" or http.request.uri.path eq "/site-revision.json" or starts_with(http.request.uri.path, "/styles.") or starts_with(http.request.uri.path, "/script.") or starts_with(http.request.uri.path, "/assets/")))',
+            action: 'set_cache_settings',
+            action_parameters: { cache: false },
+            enabled: true,
+        },
+    },
 };
 
 function fail(message) {
     throw new Error(`[cloudflare-cache] ${message}`);
+}
+
+function getTarget(value = process.env[TARGET_ENV] || 'gym') {
+    if (!Object.hasOwn(TARGET_CONFIGS, value)) {
+        fail(`${TARGET_ENV} must be one of: ${Object.keys(TARGET_CONFIGS).join(', ')}`);
+    }
+    return value;
+}
+
+function getExpectedRevision(value = process.env[EXPECTED_REVISION_ENV] || '') {
+    if (value && /\s/.test(value)) fail(`${EXPECTED_REVISION_ENV} must not contain whitespace`);
+    return value;
+}
+
+function getTargetRoot(target) {
+    return path.resolve(ROOT, '..', TARGET_CONFIGS[target].targetDirectory);
 }
 
 function getToken() {
@@ -46,40 +93,81 @@ function validateCloudflareId(value, label) {
     return value;
 }
 
-function normalizeBaseUrl(value = PUBLIC_BASE_URL) {
-    const base = new URL(value);
-    if (base.search || base.hash) fail('the fixed Gym public URL must not contain a query or fragment');
-    if (base.origin !== 'https://codeoverdose.es' || base.pathname !== '/gym/') {
-        fail('the cache control surface is fixed to https://codeoverdose.es/gym/');
+function validatePortfolioRevision(siteRevision, expectedRevision) {
+    if (!siteRevision || typeof siteRevision !== 'object' || siteRevision.schema !== 1) {
+        fail('site-revision.json does not contain the expected schema');
     }
-    return base;
+    if (!/^[a-f0-9]{12}-[a-f0-9]{12}$/.test(siteRevision.revision || '')) {
+        fail('site-revision.json has an invalid portfolio revision');
+    }
+    if (expectedRevision && siteRevision.revision !== expectedRevision) {
+        fail(`portfolio revision ${siteRevision.revision} does not match expected ${expectedRevision}`);
+    }
+
+    const cssPath = siteRevision.assets?.css?.path;
+    const jsPath = siteRevision.assets?.js?.path;
+    const cssMatch = /^styles\.([a-f0-9]{12})\.css$/.exec(cssPath || '');
+    const jsMatch = /^script\.([a-f0-9]{12})\.js$/.exec(jsPath || '');
+    if (!cssMatch || !jsMatch) fail('portfolio revision does not declare content-addressed CSS and JS');
+    if (!/^[a-f0-9]{64}$/.test(siteRevision.assets.css.sha256 || '')) {
+        fail('portfolio CSS manifest hash is invalid');
+    }
+    if (!/^[a-f0-9]{64}$/.test(siteRevision.assets.js.sha256 || '')) {
+        fail('portfolio JS manifest hash is invalid');
+    }
+    if (!siteRevision.assets.css.sha256.startsWith(cssMatch[1])) {
+        fail('portfolio CSS filename does not match its manifest hash');
+    }
+    if (!siteRevision.assets.js.sha256.startsWith(jsMatch[1])) {
+        fail('portfolio JS filename does not match its manifest hash');
+    }
+    return siteRevision;
 }
 
-function getCanonicalUrls(release) {
-    if (!release || typeof release !== 'object' || !release.assets || typeof release.assets !== 'object') {
+function validateTargetMetadata(target, metadata, expectedRevision) {
+    if (target === 'portfolio') return validatePortfolioRevision(metadata, expectedRevision);
+    if (!metadata || typeof metadata !== 'object' || !metadata.assets || typeof metadata.assets !== 'object') {
         fail('release.json does not contain a usable asset manifest');
     }
+    if (expectedRevision && metadata.revision !== expectedRevision) {
+        fail(`Gym revision ${metadata.revision} does not match expected ${expectedRevision}`);
+    }
+    return metadata;
+}
 
-    const base = normalizeBaseUrl();
-    const paths = new Set(['', 'index.html', 'manifest.json', 'release.json', 'sw.js', ...Object.keys(release.assets)]);
-    return [...paths].sort().map(asset => {
-        if (asset && (/^[a-z][a-z\d+.-]*:/i.test(asset) || asset.startsWith('//') || asset.startsWith('/'))) {
-            fail(`release asset is not a relative Gym path: ${asset}`);
+async function readTargetMetadata(target) {
+    const config = TARGET_CONFIGS[target];
+    try {
+        return JSON.parse(await fs.readFile(path.join(getTargetRoot(target), config.metadataFile), 'utf8'));
+    } catch (error) {
+        fail(`could not read ${config.metadataFile} for ${target}: ${error.message}`);
+    }
+}
+
+function toCanonicalUrls(target, metadata) {
+    const config = TARGET_CONFIGS[target];
+    const paths = new Set(config.fixedPaths);
+    if (target === 'gym') {
+        Object.keys(metadata.assets).forEach(asset => paths.add(asset));
+    } else {
+        paths.add(metadata.assets.css.path);
+        paths.add(metadata.assets.js.path);
+    }
+
+    const base = new URL(config.baseUrl);
+    return [...paths].sort().map(relativePath => {
+        if (
+            relativePath &&
+            (/^[a-z][a-z\d+.-]*:/i.test(relativePath) || relativePath.startsWith('//') || relativePath.startsWith('/'))
+        ) {
+            fail(`${target} release asset is not a relative path: ${relativePath}`);
         }
-        const url = new URL(asset, base);
+        const url = new URL(relativePath, base);
         if (url.origin !== base.origin || url.search || url.hash || !url.pathname.startsWith(base.pathname)) {
-            fail(`release asset escapes the fixed Gym purge scope: ${asset}`);
+            fail(`${target} release asset escapes the fixed purge scope: ${relativePath}`);
         }
         return url.toString();
     });
-}
-
-async function readRelease() {
-    try {
-        return JSON.parse(await fs.readFile(path.join(ROOT, 'release.json'), 'utf8'));
-    } catch (error) {
-        fail(`could not read release.json: ${error.message}`);
-    }
 }
 
 export async function cloudflareRequest(token, requestPath, options = {}) {
@@ -106,12 +194,13 @@ export async function cloudflareRequest(token, requestPath, options = {}) {
     }
 
     if (!response.ok || !payload?.success) {
-        const codes = Array.isArray(payload?.errors)
-            ? payload.errors
-                  .map(error => error?.code)
-                  .filter(Boolean)
-                  .join(',')
-            : 'unknown';
+        let codes = 'unknown';
+        if (Array.isArray(payload?.errors)) {
+            codes = payload.errors
+                .map(error => error?.code)
+                .filter(Boolean)
+                .join(',');
+        }
         const error = new Error(
             `[cloudflare-cache] ${options.method || 'GET'} ${requestPath} failed with HTTP ${response.status} (Cloudflare error codes: ${codes})`
         );
@@ -164,18 +253,18 @@ async function getCacheRuleEntrypoint(token, zoneId, request = cloudflareRequest
     }
 }
 
-function cacheRuleMatches(rule) {
+function cacheRuleMatches(rule, expectedRule) {
     return (
-        rule?.ref === TARGET_CACHE_RULE.ref &&
-        rule.expression === TARGET_CACHE_RULE.expression &&
-        rule.action === TARGET_CACHE_RULE.action &&
+        rule?.ref === expectedRule.ref &&
+        rule.expression === expectedRule.expression &&
+        rule.action === expectedRule.action &&
         rule.action_parameters?.cache === false &&
         rule.enabled !== false
     );
 }
 
-async function reconcileCachePolicy(token, zoneId, request = cloudflareRequest) {
-    const entrypointPath = `/zones/${zoneId}/rulesets/phases/${CACHE_RULE_PHASE}/entrypoint`;
+async function reconcileCachePolicy(target, token, zoneId, request = cloudflareRequest) {
+    const targetRule = TARGET_CONFIGS[target].cacheRule;
     let entrypoint = await getCacheRuleEntrypoint(token, zoneId, request);
     let operation = 'verified';
 
@@ -184,44 +273,44 @@ async function reconcileCachePolicy(token, zoneId, request = cloudflareRequest) 
             method: 'POST',
             body: JSON.stringify({
                 kind: 'zone',
-                name: 'Gym release delivery cache policy',
-                description: 'Fixed no-store Cloudflare policy for codeoverdose.es/gym/',
+                name: `${target} fixed canonical delivery cache policy`,
+                description: `Fixed no-store Cloudflare policy for ${target} canonical delivery`,
                 phase: CACHE_RULE_PHASE,
-                rules: [TARGET_CACHE_RULE],
+                rules: [targetRule],
             }),
         });
         operation = 'created';
     } else {
         const rules = Array.isArray(entrypoint.rules) ? entrypoint.rules : [];
-        const existingRule = rules.find(rule => rule?.ref === CACHE_RULE_REF);
+        const existingRule = rules.find(rule => rule?.ref === targetRule.ref);
 
         if (!existingRule) {
             if (!entrypoint.id) fail('Cloudflare cache ruleset did not return an id');
             await request(token, `/zones/${zoneId}/rulesets/${entrypoint.id}/rules`, {
                 method: 'POST',
                 body: JSON.stringify({
-                    ...TARGET_CACHE_RULE,
+                    ...targetRule,
                     position: { before: rules[0]?.id || '' },
                 }),
             });
             operation = 'added';
-        } else if (!cacheRuleMatches(existingRule)) {
-            if (!existingRule.id) fail('existing Gym cache rule did not return an id');
+        } else if (!cacheRuleMatches(existingRule, targetRule)) {
+            if (!existingRule.id) fail(`existing ${target} cache rule did not return an id`);
             await request(token, `/zones/${zoneId}/rulesets/${entrypoint.id}/rules/${existingRule.id}`, {
                 method: 'PATCH',
-                body: JSON.stringify(TARGET_CACHE_RULE),
+                body: JSON.stringify(targetRule),
             });
             operation = 'updated';
         }
     }
 
     entrypoint = await getCacheRuleEntrypoint(token, zoneId, request);
-    const verifiedRule = entrypoint?.rules?.find(rule => rule?.ref === CACHE_RULE_REF);
-    if (!cacheRuleMatches(verifiedRule)) {
-        fail('Cloudflare did not expose the expected fixed /gym/ cache policy after reconciliation');
+    const verifiedRule = entrypoint?.rules?.find(rule => rule?.ref === targetRule.ref);
+    if (!cacheRuleMatches(verifiedRule, targetRule)) {
+        fail(`Cloudflare did not expose the expected fixed ${target} cache policy after reconciliation`);
     }
 
-    return { operation, rulesetId: entrypoint.id };
+    return { operation, rulesetId: entrypoint.id, ref: targetRule.ref };
 }
 
 async function purgeUrls(token, zoneId, urls, request = cloudflareRequest) {
@@ -238,32 +327,43 @@ async function purgeUrls(token, zoneId, urls, request = cloudflareRequest) {
     return purgeIds;
 }
 
-export async function execute({ token = getToken(), release = null, request = cloudflareRequest } = {}) {
+export async function execute({
+    target = getTarget(),
+    expectedRevision = getExpectedRevision(),
+    metadata = null,
+    release = null,
+    token = null,
+    request = cloudflareRequest,
+} = {}) {
+    target = getTarget(target);
     if (!process.argv.includes('--validate-and-purge') && request === cloudflareRequest) {
         fail('run with --validate-and-purge to make the intended cache action explicit');
     }
 
-    const releaseManifest = release || (await readRelease());
-    const urls = getCanonicalUrls(releaseManifest);
-    const zone = await resolveZone(token, request);
+    const targetMetadata = validateTargetMetadata(
+        target,
+        metadata || release || (await readTargetMetadata(target)),
+        expectedRevision
+    );
+    const urls = toCanonicalUrls(target, targetMetadata);
+    const cacheToken = token || getToken();
+    const zone = await resolveZone(cacheToken, request);
     const accountId = resolveAccountId(zone.accountId);
-    await verifyAccountToken(token, accountId, request);
-    const policy = await reconcileCachePolicy(token, zone.id, request);
-    const purgeIds = await purgeUrls(token, zone.id, urls, request);
-    const releaseDigest = crypto
-        .createHash('sha256')
-        .update(JSON.stringify(releaseManifest))
-        .digest('hex')
-        .slice(0, 12);
+    await verifyAccountToken(cacheToken, accountId, request);
+    const policy = await reconcileCachePolicy(target, cacheToken, zone.id, request);
+    const purgeIds = await purgeUrls(cacheToken, zone.id, urls, request);
+    const manifest = crypto.createHash('sha256').update(JSON.stringify(targetMetadata)).digest('hex').slice(0, 12);
 
     return {
+        target,
         accountId,
         zoneId: zone.id,
         policy,
         purgeIds,
         urlCount: urls.length,
-        release: releaseManifest.revision,
-        manifest: releaseDigest,
+        release: target === 'portfolio' ? targetMetadata.revision : targetMetadata.revision,
+        manifest,
+        urls,
     };
 }
 
@@ -272,7 +372,7 @@ if (isMain) {
     execute()
         .then(result => {
             console.log(
-                `[cloudflare-cache] active account token verified; /gym/ cache policy ${result.policy.operation}; purged ${result.urlCount} canonical URLs in ${result.purgeIds.length} batches for ${ZONE_NAME} (release ${result.release}, manifest ${result.manifest})`
+                `[cloudflare-cache] target ${result.target}; active account token verified; policy ${result.policy.operation}; purged ${result.urlCount} canonical URLs in ${result.purgeIds.length} batches for ${ZONE_NAME} (revision ${result.release}, manifest ${result.manifest})`
             );
         })
         .catch(error => {

--- a/scripts/production-release-smoke.mjs
+++ b/scripts/production-release-smoke.mjs
@@ -7,12 +7,24 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const PUBLIC_BASE_URL = process.env.GYM_PUBLIC_BASE_URL || 'https://codeoverdose.es/gym/';
+const SMOKE_TARGET = process.env.PRODUCTION_SMOKE_TARGET || 'gym';
+const GYM_PUBLIC_BASE_URL = 'https://codeoverdose.es/gym/';
+const PORTFOLIO_PUBLIC_BASE_URL = 'https://codeoverdose.es/';
 const RETRY_COUNT = Number(process.env.PRODUCTION_SMOKE_RETRY_COUNT || 12);
 const RETRY_DELAY_MS = Number(process.env.PRODUCTION_SMOKE_RETRY_DELAY_MS || 5_000);
 const CORE_ASSETS = ['', 'index.html', 'manifest.json', 'release.json', 'sw.js', 'js/progress.js'];
+const PORTFOLIO_MEDIA_PATHS = [
+    'assets/1.png',
+    'assets/2.png',
+    'assets/2048.webp',
+    'assets/cc.webp',
+    'assets/gym-icon.png',
+    'assets/luckbound_concept.jpg',
+    'assets/logo.png',
+];
 const REVISION_PATTERN = /const RELEASE_REVISION = ['"]([^'"]+)['"]/;
 const META_PATTERN = /<meta\s+name=["']gym-release-revision["']\s+content=["']([^"']+)["']/i;
+const PORTFOLIO_META_PATTERN = /<meta\s+name=["']codeoverdose:revision["']\s+content=["']([^"']+)["']/i;
 
 function fail(layer, message) {
     const error = new Error(`[production-smoke:${layer}] ${message}`);
@@ -85,7 +97,7 @@ function normalizeShellHtml(value) {
         )
         .replace(/<link\s+rel="preconnect"\s+href="https:\/\/fonts\.googleapis\.com"\s*\/?>/gi, '')
         .replace(/<link\s+rel="preconnect"\s+href="https:\/\/fonts\.gstatic\.com"\s+crossorigin\s*\/?>/gi, '')
-        .replace(/<link\s+href="https:\/\/fonts\.googleapis\.com\/css2\?[^\"]+"\s+rel="stylesheet"\s*\/?>/gi, '')
+        .replace(/<link\s+href="https:\/\/fonts\.googleapis\.com\/css2\?[^"]+"\s+rel="stylesheet"\s*\/?>/gi, '')
         .replace(/\[email&#160;protected\]/gi, '[email-protected]')
         .replace(
             /<a\s+href="mailto:contact@codeoverdose\.es">contact@codeoverdose\.es<\/a>/gi,
@@ -151,9 +163,12 @@ async function fetchAsset(base, relativePath) {
     try {
         response = await fetch(url, {
             headers: {
+                Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+                'Accept-Language': 'en-US,en;q=0.9',
                 'Cache-Control': 'no-cache',
                 Pragma: 'no-cache',
-                'User-Agent': 'gym-production-release-smoke/1.0',
+                'User-Agent':
+                    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
             },
         });
     } catch (error) {
@@ -273,10 +288,176 @@ function validateRelease(release, assets, checkedOutIndexHtml) {
     return { revision: expectedRevision, version: manifest.version, progressHash };
 }
 
-function buildEvidence(release, assets, validation) {
+function portfolioTargetRoot() {
+    return path.resolve(ROOT, '..', 'target-portfolio');
+}
+
+async function readPortfolioTarget() {
+    const targetRoot = portfolioTargetRoot();
+    try {
+        const siteRevision = JSON.parse(await fs.readFile(path.join(targetRoot, 'site-revision.json'), 'utf8'));
+        const checkedOutIndexHtml = normalizeText(await fs.readFile(path.join(targetRoot, 'index.html')));
+        if (siteRevision.schema !== 1 || siteRevision.entrypoint !== 'index.html') {
+            fail('manifest', 'checked-out portfolio site-revision.json has an invalid shape');
+        }
+        if (!/^[a-f0-9]{12}-[a-f0-9]{12}$/.test(siteRevision.revision || '')) {
+            fail('manifest', `checked-out portfolio revision is invalid: ${siteRevision.revision}`);
+        }
+        const cssPath = siteRevision.assets?.css?.path;
+        const jsPath = siteRevision.assets?.js?.path;
+        if (!/^styles\.[a-f0-9]{12}\.css$/.test(cssPath || '') || !/^script\.[a-f0-9]{12}\.js$/.test(jsPath || '')) {
+            fail('manifest', 'checked-out portfolio assets are not content-addressed');
+        }
+        const assetPaths = [...new Set([cssPath, jsPath, ...PORTFOLIO_MEDIA_PATHS])];
+        const localHashes = {};
+        for (const relativePath of assetPaths) {
+            const bytes = await fs.readFile(path.join(targetRoot, relativePath));
+            localHashes[relativePath] = sha256(bytes, relativePath);
+        }
+        if (siteRevision.assets.css.sha256 !== localHashes[cssPath]) {
+            fail('manifest', `checked-out portfolio CSS hash disagrees with ${cssPath}`);
+        }
+        if (siteRevision.assets.js.sha256 !== localHashes[jsPath]) {
+            fail('manifest', `checked-out portfolio JS hash disagrees with ${jsPath}`);
+        }
+        return { siteRevision, checkedOutIndexHtml, localHashes };
+    } catch (error) {
+        if (error.layer) throw error;
+        fail('pages', `could not read the checked-out portfolio target: ${error.message}`);
+    }
+}
+
+function getPortfolioExpectedAssets(siteRevision) {
+    return [
+        '',
+        'index.html',
+        'site-revision.json',
+        siteRevision.assets.css.path,
+        siteRevision.assets.js.path,
+        ...PORTFOLIO_MEDIA_PATHS,
+    ].sort();
+}
+
+function validatePortfolio(siteRevision, assets, checkedOutIndexHtml, localHashes) {
+    let remoteRevision;
+    try {
+        remoteRevision = JSON.parse(normalizeText(assets['site-revision.json'].buffer));
+    } catch (error) {
+        fail('manifest', `production site-revision.json is not valid JSON: ${error.message}`);
+    }
+    if (JSON.stringify(remoteRevision) !== JSON.stringify(siteRevision)) {
+        fail('cloudflare', `site-revision.json does not match deployed portfolio revision ${siteRevision.revision}`);
+    }
+
+    const rootHtml = normalizeText(assets[''].buffer);
+    const indexHtml = normalizeText(assets['index.html'].buffer);
+    const requiredMarkers = [
+        'https://codeoverdose.es/',
+        'Taskify',
+        'Firestore',
+        'id="project-6"',
+        'hreflang="es"',
+        '<dialog',
+    ];
+    for (const marker of requiredMarkers) {
+        if (!rootHtml.includes(marker)) fail('cloudflare', `canonical portfolio root is missing ${marker}`);
+        if (!indexHtml.includes(marker)) fail('pages', `portfolio index.html is missing ${marker}`);
+    }
+    if (rootHtml.match(PORTFOLIO_META_PATTERN)?.[1] !== siteRevision.revision) {
+        fail('cloudflare', `canonical portfolio root revision disagrees with ${siteRevision.revision}`);
+    }
+    if (indexHtml.match(PORTFOLIO_META_PATTERN)?.[1] !== siteRevision.revision) {
+        fail('pages', `portfolio index.html revision disagrees with ${siteRevision.revision}`);
+    }
+    if (normalizeShellHtml(rootHtml) !== normalizeShellHtml(indexHtml)) {
+        fail('cloudflare', 'canonical portfolio root differs from /index.html after Cloudflare markup normalization');
+    }
+
+    const cssPath = siteRevision.assets.css.path;
+    const jsPath = siteRevision.assets.js.path;
+    if (!rootHtml.includes(`href="${cssPath}"`) || !indexHtml.includes(`href="${cssPath}"`)) {
+        fail('cloudflare', `portfolio HTML does not reference ${cssPath}`);
+    }
+    if (!rootHtml.includes(`src="${jsPath}"`) || !indexHtml.includes(`src="${jsPath}"`)) {
+        fail('cloudflare', `portfolio HTML does not reference ${jsPath}`);
+    }
+    if (rootHtml.includes('href="styles.css"') || indexHtml.includes('href="styles.css"')) {
+        fail('cloudflare', 'portfolio HTML still references mutable styles.css');
+    }
+    if (rootHtml.includes('src="script.js"') || indexHtml.includes('src="script.js"')) {
+        fail('cloudflare', 'portfolio HTML still references mutable script.js');
+    }
+    for (const relativePath of [cssPath, jsPath, ...PORTFOLIO_MEDIA_PATHS]) {
+        const actualHash = sha256(assets[relativePath].buffer, relativePath);
+        const expectedHash = localHashes[relativePath];
+        if (actualHash !== expectedHash) {
+            fail('cloudflare', `${relativePath} bytes do not match the checked-out portfolio revision`);
+        }
+    }
+    if (normalizeShellHtml(indexHtml) !== normalizeShellHtml(checkedOutIndexHtml)) {
+        fail('pages', 'deployed /index.html differs from the checked-out portfolio shell');
+    }
+
+    return { revision: siteRevision.revision, assetCount: Object.keys(localHashes).length };
+}
+
+function assertStableResponses(first, second) {
+    for (const relativePath of Object.keys(first)) {
+        const firstFingerprint =
+            relativePath === '' || relativePath === 'index.html'
+                ? normalizeShellHtml(normalizeText(first[relativePath].buffer))
+                : sha256(first[relativePath].buffer, relativePath);
+        const secondFingerprint =
+            relativePath === '' || relativePath === 'index.html'
+                ? normalizeShellHtml(normalizeText(second[relativePath].buffer))
+                : sha256(second[relativePath].buffer, relativePath);
+        if (firstFingerprint !== secondFingerprint) {
+            fail('cloudflare', `repeated no-query response changed for ${relativePath || '/'}`);
+        }
+    }
+}
+
+async function runPortfolio() {
+    const target = await readPortfolioTarget();
+    const base = normalizeBaseUrl(PORTFOLIO_PUBLIC_BASE_URL);
+    const expectedAssets = getPortfolioExpectedAssets(target.siteRevision);
+    let lastError;
+
+    for (let attempt = 1; attempt <= RETRY_COUNT; attempt += 1) {
+        try {
+            const assets = await readProduction(base, expectedAssets);
+            const validation = validatePortfolio(
+                target.siteRevision,
+                assets,
+                target.checkedOutIndexHtml,
+                target.localHashes
+            );
+            const repeatedAssets = await readProduction(base, expectedAssets);
+            assertStableResponses(assets, repeatedAssets);
+            const evidence = buildEvidence(target.siteRevision, assets, validation, PORTFOLIO_PUBLIC_BASE_URL);
+            const evidencePath = process.env.PRODUCTION_SMOKE_EVIDENCE_PATH;
+            if (evidencePath) {
+                await fs.writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+            }
+            console.log(
+                `[production-smoke] passed portfolio ${validation.revision}; verified ${expectedAssets.length} repeated no-query canonical assets`
+            );
+            return;
+        } catch (error) {
+            lastError = error;
+            if (attempt === RETRY_COUNT) break;
+            console.warn(`[production-smoke] attempt ${attempt}/${RETRY_COUNT} did not converge: ${error.message}`);
+            await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+        }
+    }
+
+    throw lastError;
+}
+
+function buildEvidence(release, assets, validation, publicBaseUrl = GYM_PUBLIC_BASE_URL) {
     return {
         status: 'passed',
-        publicBaseUrl: PUBLIC_BASE_URL,
+        publicBaseUrl,
         revision: validation.revision,
         version: validation.version,
         progressHash: validation.progressHash,
@@ -294,8 +475,8 @@ function buildEvidence(release, assets, validation) {
     };
 }
 
-async function run() {
-    const base = normalizeBaseUrl(PUBLIC_BASE_URL);
+async function runGym() {
+    const base = normalizeBaseUrl(GYM_PUBLIC_BASE_URL);
     const release = await readLocalRelease();
     const expectedAssets = getExpectedAssets(release);
     let lastError;
@@ -323,6 +504,12 @@ async function run() {
     }
 
     throw lastError;
+}
+
+async function run() {
+    if (SMOKE_TARGET === 'portfolio') return runPortfolio();
+    if (SMOKE_TARGET !== 'gym') fail('config', 'PRODUCTION_SMOKE_TARGET must be gym or portfolio');
+    return runGym();
 }
 
 run().catch(error => {

--- a/tests/unit/cloudflare-cache-control.test.js
+++ b/tests/unit/cloudflare-cache-control.test.js
@@ -15,6 +15,22 @@ const release = {
     },
 };
 
+const portfolioRevision = {
+    schema: 1,
+    revision: '8a6775e69351-8d644fa8d579',
+    entrypoint: 'index.html',
+    assets: {
+        css: {
+            path: 'styles.8a6775e69351.css',
+            sha256: '8a6775e69351' + 'a'.repeat(52),
+        },
+        js: {
+            path: 'script.8d644fa8d579.js',
+            sha256: '8d644fa8d579' + 'b'.repeat(52),
+        },
+    },
+};
+
 function success(result) {
     return {
         ok: true,
@@ -44,7 +60,16 @@ function targetRule(overrides = {}) {
     };
 }
 
-function makeFetch({ entrypoint }) {
+function portfolioRule() {
+    return targetRule({
+        ref: 'portfolio-canonical-cache-policy-v1',
+        description: 'Bypass Cloudflare caching for CodeOverdose portfolio delivery',
+        expression:
+            '(http.host eq "codeoverdose.es" and (http.request.uri.path eq "/" or http.request.uri.path eq "/index.html" or http.request.uri.path eq "/site-revision.json" or starts_with(http.request.uri.path, "/styles.") or starts_with(http.request.uri.path, "/script.") or starts_with(http.request.uri.path, "/assets/")))',
+    });
+}
+
+function makeFetch({ entrypoint, rule = targetRule() }) {
     const requests = [];
     let createdRule = null;
     const fetchMock = jest.fn(async (url, options = {}) => {
@@ -62,7 +87,7 @@ function makeFetch({ entrypoint }) {
             parsedUrl.pathname === `/client/v4/zones/${ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint`
         ) {
             if (entrypoint === 'missing' && !createdRule) return failure(404);
-            return success({ id: RULESET_ID, rules: createdRule ? [createdRule] : [targetRule()] });
+            return success({ id: RULESET_ID, rules: createdRule ? [createdRule] : [rule] });
         }
         if (parsedUrl.pathname === `/client/v4/zones/${ZONE_ID}/rulesets` && method === 'POST') {
             createdRule = { ...JSON.parse(options.body).rules[0], id: RULE_ID };
@@ -144,5 +169,47 @@ describe('Cloudflare cache control', () => {
                 request => request.method === 'POST' && request.url.pathname.endsWith(`/rulesets/${RULESET_ID}/rules`)
             )
         ).toBe(false);
+    });
+
+    it('supports only the fixed portfolio target and purges its closed canonical path set', async () => {
+        const { fetchMock, requests } = makeFetch({ entrypoint: 'missing', rule: portfolioRule() });
+        globalThis.fetch = fetchMock;
+
+        const result = await execute({
+            target: 'portfolio',
+            expectedRevision: portfolioRevision.revision,
+            metadata: portfolioRevision,
+            token: 'test-account-token',
+            request: (token, requestPath, options) => cloudflareRequest(token, requestPath, options),
+        });
+
+        expect(result.target).toBe('portfolio');
+        expect(result.release).toBe(portfolioRevision.revision);
+        expect(result.urlCount).toBe(14);
+
+        const purgeRequest = requests.find(request => request.url.pathname.endsWith('/purge_cache'));
+        const purgeBody = JSON.parse(purgeRequest.options.body);
+        const purgedPaths = purgeBody.files.map(url => new URL(url).pathname).sort();
+        expect(purgedPaths).toEqual([
+            '/',
+            '/assets/1.png',
+            '/assets/2.png',
+            '/assets/2048.webp',
+            '/assets/cc.webp',
+            '/assets/gym-icon.png',
+            '/assets/logo.png',
+            '/assets/luckbound_concept.jpg',
+            '/index.html',
+            '/script.8d644fa8d579.js',
+            '/script.js',
+            '/site-revision.json',
+            '/styles.8a6775e69351.css',
+            '/styles.css',
+        ]);
+        expect(purgeBody.files.every(url => new URL(url).origin === 'https://codeoverdose.es')).toBe(true);
+        expect(purgeBody.files.some(url => url.includes('?'))).toBe(false);
+        expect(requests.some(request => request.url.pathname.endsWith('/purge_everything'))).toBe(false);
+        const policyRequest = requests.find(request => request.url.pathname.endsWith('/rulesets'));
+        expect(JSON.parse(policyRequest.options.body).rules[0].ref).toBe('portfolio-canonical-cache-policy-v1');
     });
 });


### PR DESCRIPTION
Adds the approved fixed-target Cloudflare control-plane path for the CodeOverdose portfolio. The workflow accepts only target=gym|portfolio plus a deployed commit and expected immutable revision; it validates the account token through the fixed endpoint, preserves unrelated rules, reconciles the named portfolio rule, purges only the closed canonical URL set, and runs bounded no-query smoke with realistic browser headers. No secrets are read or copied and no zone-wide purge is used. Portfolio PR: https://github.com/metalfurius/metalfurius.github.io/pull/5