### PR TITLE
fix: add accessible Progress chart alternative

### DIFF
--- a/js/progress.js
+++ b/js/progress.js
@@ -583,13 +583,21 @@ function createOrUpdateChart(chartData, exerciseName, metric) {
         reps: t('progress.metric_reps'),
         volume: `${t('progress.metric_volume')} (${t('progress.unit_volume')})`
     };
+    const metricLabel = metricLabels[metric] || t('progress.value');
+    const chartTitle = t('progress.chart_title', { exercise: exerciseName, metric: metricLabel });
+    const accessibleData = chartData.labels
+        .map((label, index) => `${label}: ${chartData.data[index]}`)
+        .join('; ');
+
+    progressElements.chart.setAttribute('role', 'img');
+    progressElements.chart.setAttribute('aria-label', `${chartTitle}. ${accessibleData}`);
 
     progressChart = new Chart(ctx, {
         type: 'line',
         data: {
             labels: chartData.labels,
             datasets: [{
-                label: metricLabels[metric] || t('progress.value'),
+                label: metricLabel,
                 data: chartData.data,
                 borderColor: 'rgb(102, 126, 234)',
                 backgroundColor: 'rgba(102, 126, 234, 0.1)',
@@ -608,7 +616,7 @@ function createOrUpdateChart(chartData, exerciseName, metric) {
             plugins: {
                 title: {
                     display: true,
-                    text: t('progress.chart_title', { exercise: exerciseName, metric: metricLabels[metric] }),
+                    text: chartTitle,
                     font: {
                         size: 16,
                         weight: 'bold'

--- a/release.json
+++ b/release.json
@@ -39,7 +39,7 @@
     "js/modules/scroll-to-top.js": "109544403dade6bfd1ba0490a6353aa8c784f8c261763004fa52723c326b5481",
     "js/modules/session-manager.js": "fb1468e2d02a4c3be8db18aa25a1c1569131a50a0fd63e73b2058cdddab559d7",
     "js/modules/settings.js": "ed8bcedc1e57d63884ceef459316c0f2d8d52dafc64ede3cc3b456e8eed534db",
-    "js/progress.js": "4610b2e4bfb04d5e82baaec508d3a22b85301f4180a3b288080f40179160d181",
+    "js/progress.js": "038ac3fd4c368fe3ed6ed848263328f27a32783d182b6d64c9686b4dc537bb0e",
     "js/storage-manager.js": "2cbc62562ffaf2fa01f4b5aaaa32ded1e3cabe18e19524291883adabf6f4f9e7",
     "js/theme-manager.js": "9a4fc89d69fe220a7df593675628fed896bd491e9474cd5c050a2699d130a3c9",
     "js/timer.js": "0150948fa2b426832aac87409d4142a6d60b05b1569553d759dbc274c04c83cd",

--- a/tests/unit/progress-flow.test.js
+++ b/tests/unit/progress-flow.test.js
@@ -320,6 +320,9 @@ describe('progress flow', () => {
         expect(progressElements.chartContainer.classList.contains('hidden')).toBe(false);
         expect(progressElements.statsContainer.classList.contains('hidden')).toBe(false);
         expect(progressElements.noDataMessage.classList.contains('hidden')).toBe(true);
+        expect(progressElements.chart.getAttribute('role')).toBe('img');
+        expect(progressElements.chart.getAttribute('aria-label')).toContain('Bench Press');
+        expect(progressElements.chart.getAttribute('aria-label')).toContain('60');
         expect(progressElements.bestRecord.textContent).toBe('72.0 kg');
         expect(progressElements.sessionCount.textContent).toBe('4');
         expect(progressElements.totalProgress.textContent).toBe('+12.0 kg');


### PR DESCRIPTION
## Scope

Minimal linked repair for the Progress history acceptance work in #78. Adds a programmatic chart alternative (role=img plus an exercise/metric/data aria-label) and a focused regression test. No schema, history, cache, or UI redesign changes.

## Evidence

- npm run lint:ratchet
- npm run test:no-skips
- npm run test:unit — 648
- npm run test:integration — 45
- npm run test:coverage:gate — 72.27% statements
- npm run test:app — 5/5
- npm run test:app:offline — 2/2
- npm run release:check
- Real Chromium synthetic long-history harness: 3m/6m/1y/all = 3/6/9/11, save/reload 11→12, offline restart 12, reconnect, desktop/mobile screenshots, bounded limit=300 Progress reads, zero console/request failures.

Production canonical smoke is separately recorded; completion remains blocked by a byte mismatch for the public no-query index.html edge response against v2.7.12 release.json (54/55 assets match, index is a CF-HIT). No deploy is included in this PR.

Refs: #78, #77